### PR TITLE
Errors inside CA API call reply msgs are translated to Go errors on cmds

### DIFF
--- a/cmds/base.go
+++ b/cmds/base.go
@@ -155,6 +155,10 @@ func (edge Edge) MsgToCA(w io.Writer,
 	if ipl.Type == pltype.ConnectionError {
 		return mesg.Msg{}, fmt.Errorf("%v", ipl.Message.Error)
 	}
+	if ipl.Message.Error != "" {
+		return mesg.Msg{}, fmt.Errorf("msg to ca: %v", ipl.Message.Error)
+	}
+
 	return ipl.Message, nil
 }
 


### PR DESCRIPTION
- like create schema, it returns errors as internal msg fields, they are now translated to Go errors on cmnds