### PR TITLE
Add accept step to cred/proof propose flow 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: test
-        run: make test
+        run: make testv
         env:
           TEST_WORKDIR: /github/home/.test/
           CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: test
-        run: make testv
+        run: make test
         env:
           TEST_WORKDIR: /github/home/.test/
           CI: true

--- a/client/client.go
+++ b/client/client.go
@@ -487,7 +487,7 @@ func (edge *Client) PwAndProofProp(
 			RecipientKeys:   []string{endpKey},
 			Label:           edgePw,
 		},
-		CredDefID: &credDefID,
+		ProofAttrs: &[]didcomm.ProofAttribute{{Name: "email", CredDefID: ""}},
 	}
 	im := e2.Msg.Try(edge.MsgToCA(pltype.CAPairwiseAndProofProp, om))
 	log.Println("============== Task #: ", im.ID)
@@ -520,8 +520,8 @@ func (edge *Client) PwAndTrustPing(
 func (edge *Client) ProofProp(edgePw, email string) (tID string, err error) {
 	defer err2.Annotate("proof prop", &err)
 	om := &mesg.Msg{
-		Name: edgePw,
-		Info: email, // this is Values field in PresentProofRep
+		Name:       edgePw,
+		ProofAttrs: &[]didcomm.ProofAttribute{{Name: "email", CredDefID: ""}},
 	}
 	im := e2.Msg.Try(edge.MsgToCA(pltype.CAProofPropose, om))
 	log.Println("============== Task #: ", im.ID)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/findy-network/findy-agent
 go 1.16
 
 require (
-	github.com/findy-network/findy-common-go v0.1.17-0.20210831085857-3c620ead333e
+	github.com/findy-network/findy-common-go v0.1.17
 	github.com/findy-network/findy-wrapper-go v0.24.3
 	github.com/go-co-op/gocron v1.6.2
 	github.com/go-test/deep v1.0.7

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/findy-network/findy-agent
 go 1.16
 
 require (
-	github.com/findy-network/findy-common-go v0.1.15
+	github.com/findy-network/findy-common-go v0.1.17-0.20210831085857-3c620ead333e
 	github.com/findy-network/findy-wrapper-go v0.24.3
 	github.com/go-co-op/gocron v1.6.2
 	github.com/go-test/deep v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/findy-network/findy-common-go v0.1.15 h1:9AFCskiKyvlGdsQOHa4wj1hu15CfzPAf17lYjmqsxcw=
-github.com/findy-network/findy-common-go v0.1.15/go.mod h1:s+KdUrN3s2+XHZ70x3th0LFpMWX2UBofBprEwG5Rwak=
+github.com/findy-network/findy-common-go v0.1.17-0.20210831085857-3c620ead333e h1:h6IIIpIot/ImtMM8u0zGno+YuPVrJvBEmp7klekqZaU=
+github.com/findy-network/findy-common-go v0.1.17-0.20210831085857-3c620ead333e/go.mod h1:s+KdUrN3s2+XHZ70x3th0LFpMWX2UBofBprEwG5Rwak=
 github.com/findy-network/findy-wrapper-go v0.24.3 h1:rfA9G6h5G0coaqHguNnBu2f+nzccuEurRamURJqJCSs=
 github.com/findy-network/findy-wrapper-go v0.24.3/go.mod h1:t7HOvDp3OkQyPBx5+Q/epdTGl5b25nmn3vtlXweE+TM=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/findy-network/findy-common-go v0.1.17-0.20210831085857-3c620ead333e h1:h6IIIpIot/ImtMM8u0zGno+YuPVrJvBEmp7klekqZaU=
 github.com/findy-network/findy-common-go v0.1.17-0.20210831085857-3c620ead333e/go.mod h1:s+KdUrN3s2+XHZ70x3th0LFpMWX2UBofBprEwG5Rwak=
+github.com/findy-network/findy-common-go v0.1.17 h1:28+GEhvRU7jV/kB4C+31Rm9VAtO4AB1rUu9H2SefjHA=
+github.com/findy-network/findy-common-go v0.1.17/go.mod h1:s+KdUrN3s2+XHZ70x3th0LFpMWX2UBofBprEwG5Rwak=
 github.com/findy-network/findy-wrapper-go v0.24.3 h1:rfA9G6h5G0coaqHguNnBu2f+nzccuEurRamURJqJCSs=
 github.com/findy-network/findy-wrapper-go v0.24.3/go.mod h1:t7HOvDp3OkQyPBx5+Q/epdTGl5b25nmn3vtlXweE+TM=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -80,7 +80,7 @@ func taskFrom(protocol *pb.Protocol) (t *comm.Task, err error) {
 		task.Nonce = invitation.ID // Important!! we must use same id!
 		glog.V(1).Infoln("set invitation")
 	case pb.Protocol_ISSUE_CREDENTIAL:
-		if protocol.Role == pb.Protocol_INITIATOR {
+		if protocol.Role == pb.Protocol_INITIATOR || protocol.Role == pb.Protocol_ADDRESSEE {
 			credDef := protocol.GetIssueCredential()
 			if credDef == nil {
 				panic(errors.New("cred def cannot be nil for issuing protocol"))

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -105,7 +105,7 @@ func taskFrom(protocol *pb.Protocol) (t *comm.Task, err error) {
 			}
 		}
 	case pb.Protocol_PRESENT_PROOF:
-		if protocol.Role == pb.Protocol_INITIATOR {
+		if protocol.Role == pb.Protocol_INITIATOR || protocol.Role == pb.Protocol_ADDRESSEE {
 			proofReq := protocol.GetPresentProof()
 			if proofReq.GetAttributesJSON() != "" {
 				var proofAttrs []didcomm.ProofAttribute

--- a/protocol/presentproof/processor.go
+++ b/protocol/presentproof/processor.go
@@ -82,6 +82,19 @@ func startProofProtocol(ca comm.Receiver, t *comm.Task) {
 				// Note!! StartPSM() sends certain Task fields to other end
 				// as PL.Message like msg.ID, .SubMsg, .Info
 
+				attrs := make([]presentproof.Attribute, len(*t.ProofAttrs))
+				for i, attr := range *t.ProofAttrs {
+					attrs[i] = presentproof.Attribute{
+						Name:      attr.Name,
+						CredDefID: attr.CredDefID,
+					}
+				}
+				pp := presentproof.NewPreviewWithAttributes(attrs)
+
+				propose := msg.FieldObj().(*presentproof.Propose)
+				propose.PresentationProposal = pp
+				propose.Comment = t.Info // todo: for legacy tests
+
 				rep := &psm.PresentProofRep{
 					Key:        key,
 					Values:     t.Info,

--- a/protocol/presentproof/prover/handlers.go
+++ b/protocol/presentproof/prover/handlers.go
@@ -20,16 +20,13 @@ func HandleRequestPresentation(packet comm.Packet) (err error) {
 	key := psm.NewStateKey(packet.Receiver, packet.Payload.ThreadID())
 	rep, _ := psm.GetPresentProofRep(key) // ignore not found error
 
-	// If we* didn't start the Proof Protocol, we must ask user does she want
-	// to reply i.e. present a proof, ___ *we == Prover
-
-	if rep == nil || !rep.WeProposed { // we didn't start, verifier asked
-
+	if rep == nil  {
 		rep := &psm.PresentProofRep{
 			Key:        key,
 			WeProposed: false,
 		}
 		err2.Check(psm.AddPresentProofRep(rep))
+	}
 
 		sendNext, waitingNext := checkAutoPermission(packet)
 
@@ -63,34 +60,6 @@ func HandleRequestPresentation(packet comm.Packet) (err error) {
 				return true, nil
 			},
 		})
-	}
-	// user has started the proof protocol herself, we can present a proof
-	return prot.ExecPSM(prot.Transition{
-		Packet:      packet,
-		SendNext:    pltype.PresentProofPresentation,
-		WaitingNext: pltype.PresentProofACK,
-		InOut: func(connID string, im, om didcomm.MessageHdr) (ack bool, err error) {
-			defer err2.Annotate("proof req handler", &err)
-
-			agent := packet.Receiver
-			repK := psm.NewStateKey(agent, im.Thread().ID)
-			rep := e2.PresentProofRep.Try(psm.GetPresentProofRep(repK))
-
-			req := im.FieldObj().(*presentproof.Request)
-			data := err2.Bytes.Try(presentproof.ProofReqData(req))
-			rep.ProofReq = string(data)
-			err2.Check(rep.CreateProof(packet, repK.DID))
-
-			pres := om.FieldObj().(*presentproof.Presentation)
-			pres.PresentationAttaches = presentproof.NewPresentationAttach(
-				pltype.LibindyPresentationID, []byte(rep.Proof))
-
-			// Save the proof request to the Proof Rep
-			err2.Check(psm.AddPresentProofRep(rep))
-
-			return true, nil
-		},
-	})
 }
 
 func checkAutoPermission(packet comm.Packet) (next string, wait string) {

--- a/scripts/dev/docker/docker-compose.yml.template
+++ b/scripts/dev/docker/docker-compose.yml.template
@@ -17,6 +17,7 @@ services:
       FCLI_AGENCY_HOST_ADDRESS: <IP_ADDRESS>
       FCLI_AGENCY_HOST_PORT: 8088
       FCLI_AGENCY_SERVER_PORT: 8088
+      FCLI_LOGGING: '-logtostderr=true -v=10'
     ports:
       - '8088:8088'
       - '50051:50051'

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -839,7 +839,7 @@ func TestClient_PwAndCredReqAutoPermissionOn(t *testing.T) {
 	}
 }
 
-func TestClient_ProofProp(t *testing.T) {
+func TestClient_ProofPropAutoPermissionOn(t *testing.T) {
 	type args struct {
 		wallet  ssi.Wallet
 		myEndp  string
@@ -873,6 +873,10 @@ func TestClient_ProofProp(t *testing.T) {
 				BaseAddress: "http://localhost:8080",
 				Wallet:      &tt.args.wallet,
 			}
+			err := client.SetSAImpl("permissive_sa")
+			if got := err; !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("client.SetSAImpl() %v, want %v", got, tt.want)
+			}
 			tID, err := client.ProofProp(tt.args.name, tt.args.emailCr)
 			if got := err; !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("client.ProofProp() %v, want %v", got, tt.want)
@@ -884,6 +888,10 @@ func TestClient_ProofProp(t *testing.T) {
 					t.Errorf("client.TaskReady() %v, want %v", got, tt.want)
 				}
 				if ready {
+					err := client.SetSAImpl("") // remove auto accept
+					if got := err; !reflect.DeepEqual(got, tt.want) {
+						t.Errorf("client.SetSAImpl() %v, want %v", got, tt.want)
+					}
 					break
 				}
 			}
@@ -1046,7 +1054,7 @@ func TestClient_ProofRequestAutoPermissionOn(t *testing.T) {
 	}
 }
 
-func TestClient_PwAndProofProp(t *testing.T) {
+func TestClient_PwAndProofPropAutoPermissionOn(t *testing.T) {
 	type args struct {
 		wallet  ssi.Wallet
 		myEndp  string
@@ -1080,6 +1088,10 @@ func TestClient_PwAndProofProp(t *testing.T) {
 				BaseAddress: "http://localhost:8080",
 				Wallet:      &tt.args.wallet,
 			}
+			err := client.SetSAImpl("permissive_sa")
+			if got := err; !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("client.SetSAImpl() %v, want %v", got, tt.want)
+			}
 			tID, err := client.PwAndProofProp(
 				endpoint2.Endp, endpoint2.Key, tt.args.name, credDefID, tt.args.emailCr)
 			if got := err; !reflect.DeepEqual(got, tt.want) {
@@ -1093,6 +1105,10 @@ func TestClient_PwAndProofProp(t *testing.T) {
 					t.Errorf("client.TaskReady() %v, want %v", got, tt.want)
 				}
 				if ready {
+					err := client.SetSAImpl("")
+					if got := err; !reflect.DeepEqual(got, tt.want) {
+						t.Errorf("client.SetSAImpl() %v, want %v", got, tt.want)
+					}
 					break
 				}
 			}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -487,7 +487,7 @@ func Test_SetSAImpl(t *testing.T) {
 	}
 }
 
-func TestClient_CredReq(t *testing.T) {
+func TestClient_CredReqAutoPermissionOn(t *testing.T) {
 	type args struct {
 		wallet  ssi.Wallet
 		myEndp  string
@@ -523,6 +523,10 @@ func TestClient_CredReq(t *testing.T) {
 				BaseAddress: "http://localhost:8080",
 				Wallet:      &tt.args.wallet,
 			}
+			err := client.SetSAImpl("permissive_sa")
+			if got := err; !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("client.SetSAImpl() %v, want %v", got, tt.want)
+			}
 			tID, err := client.CredReq(tt.args.name, credDefID, tt.args.emailCr, tt.args.veriID)
 			if got := err; !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("client.CredReq() %v, want %v", got, tt.want)
@@ -534,6 +538,10 @@ func TestClient_CredReq(t *testing.T) {
 					t.Errorf("client.TaskReady() %v, want %v", got, tt.want)
 				}
 				if ready {
+					err := client.SetSAImpl("") // remove auto accept
+					if got := err; !reflect.DeepEqual(got, tt.want) {
+						t.Errorf("client.SetSAImpl() %v, want %v", got, tt.want)
+					}
 					break
 				}
 			}
@@ -748,7 +756,7 @@ func TestClient_PwAndTrustPing(t *testing.T) {
 			tID, err := client.PwAndTrustPing(
 				endpoint2.Endp, endpoint2.Key, tt.args.name)
 			if got := err; !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("client.PwAndCredReq() %v, want %v", got, tt.want)
+				t.Errorf("client.PwAndTrustPing() %v, want %v", got, tt.want)
 			}
 			for {
 				time.Sleep(1000 * time.Millisecond)
@@ -765,7 +773,7 @@ func TestClient_PwAndTrustPing(t *testing.T) {
 	}
 }
 
-func TestClient_PwAndCredReq(t *testing.T) {
+func TestClient_PwAndCredReqAutoPermissionOn(t *testing.T) {
 	type args struct {
 		wallet  ssi.Wallet
 		myEndp  string
@@ -801,6 +809,10 @@ func TestClient_PwAndCredReq(t *testing.T) {
 				BaseAddress: "http://localhost:8080",
 				Wallet:      &tt.args.wallet,
 			}
+			err := client.SetSAImpl("permissive_sa")
+			if got := err; !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("client.SetSAImpl() %v, want %v", got, tt.want)
+			}
 			tID, err := client.PwAndCredReq(
 				endpoint2.Endp, endpoint2.Key, tt.args.name, credDefID,
 				tt.args.emailCr, tt.args.veriID)
@@ -815,6 +827,10 @@ func TestClient_PwAndCredReq(t *testing.T) {
 					t.Errorf("client.TaskReady() %v, want %v", got, tt.want)
 				}
 				if ready {
+					err := client.SetSAImpl("") // remove auto accept
+					if got := err; !reflect.DeepEqual(got, tt.want) {
+						t.Errorf("client.SetSAImpl() %v, want %v", got, tt.want)
+					}
 					break
 				}
 			}

--- a/std/presentproof/propose_impl.go
+++ b/std/presentproof/propose_impl.go
@@ -86,6 +86,15 @@ func NewPreview(values []string, credDefID string) *Preview {
 	return prev
 }
 
+func NewPreviewWithAttributes(attrs []Attribute) *Preview {
+	prev := &Preview{
+		Type:       pltype.PresentationPreviewObj,
+		Attributes: attrs,
+		Predicates: make([]Predicate, 0),
+	}
+	return prev
+}
+
 func (p *ProposeImpl) ID() string {
 	return p.Propose.ID
 }


### PR DESCRIPTION
* refactor HandleCredentialOffer: make both flows to require accept step regardless if the protocol is started by propose or offer
* allow ADDRESSEE to start credential flow using the new API
* add autopermission flag to credential proposal tests (previously no accept step was needed)
* similar changes for proof (propose presentation)
* these changes are required due to compatibility needs with AATH framework