### PR TITLE
Replace placeholder text in question-answer-API

### DIFF
--- a/grpc/server/agent.go
+++ b/grpc/server/agent.go
@@ -236,7 +236,7 @@ func (a *agentServer) Give(ctx context.Context, answer *pb.Answer) (cid *pb.Clie
 			ClientID: answer.ClientID.ID,
 		},
 		ACK:  answer.Ack,
-		Info: "welcome from gRPC",
+		Info: answer.Info,
 	})
 
 	return &pb.ClientID{ID: answer.ClientID.ID}, nil


### PR DESCRIPTION
Issue protocol implementor tries to parse the info-field to JSON, so remove this placeholder text.