### PR TITLE
Use ssi-agent-wire Content-Type for Aries requests.

### DIFF
--- a/agent/comm/calls.go
+++ b/agent/comm/calls.go
@@ -41,7 +41,8 @@ func sendAndWaitHTTPRequest(urlStr string, msg io.Reader, timeout time.Duration)
 
 	request, _ := http.NewRequest("POST", URL.String(), msg)
 
-	request.Header.Set("Content-Type", "application/x-binary")
+	// TODO: make configurable when there is support for application/didcomm-envelope-enc
+	request.Header.Set("Content-Type", "application/ssi-agent-wire")
 
 	response, err := c.Do(request)
 	err2.Check(err)


### PR DESCRIPTION
Testing with dotnet & js agents revealed that there is a mismatch between our and their request header Content-Type. As a consequence dotnet & js agents did not handle our requests at all.