### PR TITLE
Fix setting basic message content.

### DIFF
--- a/protocol/basicmessage/basic_message_protocol.go
+++ b/protocol/basicmessage/basic_message_protocol.go
@@ -86,6 +86,9 @@ func startBasicMessage(ca comm.Receiver, t comm.Task) {
 				Delivered: true,
 			}
 			err2.Check(psm.AddBasicMessageRep(rep))
+
+			msg := om.FieldObj().(*basicmessage.Basicmessage)
+			msg.Content = bmTask.Content
 			return nil
 		},
 	}))
@@ -100,7 +103,7 @@ func handleBasicMessage(packet comm.Packet) (err error) {
 		bm := im.FieldObj().(*basicmessage.Basicmessage)
 
 		if glog.V(3) {
-			glog.Info("-- Nonce: ", im.Thread().ID)
+			glog.Info("-- Thread id: ", im.Thread().ID)
 			glog.Info("Basic msg from:", name)
 			glog.Info("Sent time:", bm.SentTime)
 			glog.Info("Content: ", bm.Content)


### PR DESCRIPTION
Apparently basic message has broken with task refactoring - content is empty. This change will fix the issue, but let's discuss online if it is the correct fix, and how the message creation worked before the changes.