### PR TITLE
Do not write pairwise DIDs to ledger.

### DIFF
--- a/agent/comm/receiver.go
+++ b/agent/comm/receiver.go
@@ -26,7 +26,7 @@ type Receiver interface {
 	AttachAPIEndp(endp service.Addr) error
 	AttachSAImpl(implID string, persistent bool)
 	AddToPWMap(me, you *ssi.DID, name string) sec.Pipe
-	SaveTheirDID(did, vk string, writeNYM bool) (err error)
+	SaveTheirDID(did, vk string) (err error)
 	CAEndp(wantWorker bool) (endP *endp.Addr)
 	AddPipeToPWMap(p sec.Pipe, name string)
 	MasterSecret() (string, error)

--- a/agent/ssi/agent.go
+++ b/agent/ssi/agent.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/findy-network/findy-agent/agent/managed"
 	"github.com/findy-network/findy-agent/agent/service"
-	"github.com/findy-network/findy-agent/agent/utils"
-	"github.com/findy-network/findy-wrapper-go"
 	"github.com/findy-network/findy-wrapper-go/did"
 	"github.com/findy-network/findy-wrapper-go/ledger"
 	"github.com/findy-network/findy-wrapper-go/pairwise"
@@ -200,7 +198,7 @@ func (a *DIDAgent) localKey(didName string) (f *Future) {
 	return
 }
 
-func (a *DIDAgent) SaveTheirDID(did, vk string, writeNYM bool) (err error) {
+func (a *DIDAgent) SaveTheirDID(did, vk string) (err error) {
 	defer err2.Return(&err)
 
 	newDID := NewDid(did, vk)
@@ -208,13 +206,8 @@ func (a *DIDAgent) SaveTheirDID(did, vk string, writeNYM bool) (err error) {
 	newDID.Store(a.Wallet())
 
 	// Previous is an async func so make sure results are ready
-	// check the errors now before writing to the ledger
 	err2.Check(newDID.StoreResult())
 
-	if writeNYM && !utils.Settings.LocalTestMode() {
-		err2.Check(a.SendNYM(newDID, a.RootDid().Did(),
-			findy.NullString, findy.NullString))
-	}
 	return nil
 }
 

--- a/protocol/connection/connection_protocol.go
+++ b/protocol/connection/connection_protocol.go
@@ -131,8 +131,8 @@ func startConnectionProtocol(ca comm.Receiver, task comm.Task) {
 	// add to the cache until all lazy fetches are called
 	ssiWA.AddDIDCache(caller)
 
-	// Write EA's new DID (caller) to CA's wallet (e.g. routing) and to ledger
-	err2.Check(ca.SaveTheirDID(caller.Did(), caller.VerKey(), true))
+	// Write EA's new DID (caller) to CA's wallet (e.g. routing)
+	err2.Check(ca.SaveTheirDID(caller.Did(), caller.VerKey()))
 
 	// Save needed data to PSM related Pairwise Representative
 	pwr := &pairwiseRep{
@@ -253,11 +253,10 @@ func handleConnectionRequest(packet comm.Packet) (err error) {
 	err2.Check(r.Err())
 
 	// It's important to SAVE new pairwise's DIDs to our CA's wallet for
-	// future routing. Everything goes thru CA. NOTE, only those DIDs
-	// which are created by us are written to the Ledger
+	// future routing. Everything goes thru CA.
 	ca := agency.RcvrCA(cnxAddr)
-	err2.Check(ca.SaveTheirDID(caller.Did(), caller.VerKey(), false))
-	err2.Check(ca.SaveTheirDID(calleePw.Callee.Did(), calleePw.Callee.VerKey(), true))
+	err2.Check(ca.SaveTheirDID(caller.Did(), caller.VerKey()))
+	err2.Check(ca.SaveTheirDID(calleePw.Callee.Did(), calleePw.Callee.VerKey()))
 
 	res := msg.FieldObj().(*didexchange.Response)
 	pipe := sec.Pipe{
@@ -344,7 +343,7 @@ func handleConnectionResponse(packet comm.Packet) (err error) {
 	// It's important to SAVE new pairwise's DIDs to our CA's wallet for
 	// future routing. Everything goes thru CA.
 	ca := agency.RcvrCA(cnxAddr)
-	err2.Check(ca.SaveTheirDID(callee.Did(), callee.VerKey(), false))
+	err2.Check(ca.SaveTheirDID(callee.Did(), callee.VerKey()))
 	// Caller DID saved when we sent Conn_Req, in case both parties are us
 
 	callee.SetAEndp(im.Endpoint())

--- a/scripts/deploy/import-wallet.sh
+++ b/scripts/deploy/import-wallet.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# ignore errors here: no harm in trying ledger creation with each startup
+set +e
+echo "Creating ledger handle..."
+[[ ! -z "$FCLI_POOL_GENESIS_TXN_FILE" ]] && ./findy-agent ledger pool create
+set -e
+
 if [ -z "$FCLI_AGENCY_STEWARD_DID" ]; then
   echo "Skipping wallet import as steward is not configured."
   exit 0
@@ -10,7 +16,6 @@ if [ -d "$FOLDER" ]; then
   echo "$FOLDER exists"
 else
   echo "$FOLDER does not exist, importing wallet"
-  [[ ! -z "$FCLI_POOL_GENESIS_TXN_FILE" ]] && ./findy-agent ledger pool create
   ./findy-agent tools import
   echo "{}" > /root/findy.json
 fi


### PR DESCRIPTION
Skip writing of pairwise DIDs to ledger: if the agent does not have endorser capabilities, the writing fails. Also, no need to store the pairwise DIDs in ledger.