### PR TITLE
Avoid os.Stat when creating empty register

### DIFF
--- a/agent/handshake/agency.go
+++ b/agent/handshake/agency.go
@@ -145,7 +145,7 @@ func LoadRegistered(filename string) (err error) {
 				key, err := enclave.WalletKeyByEmail(email)
 				keyByDid, error2 := enclave.WalletKeyByDID(rootDid)
 				if err != nil || error2 != nil {
-					glog.Warningln("cannot get wallet key:", err, email)
+					glog.Warningln("cannot get wallet key:", err, email, caDid)
 					return true
 				}
 				if key != keyByDid {

--- a/agent/utils/register.go
+++ b/agent/utils/register.go
@@ -46,17 +46,6 @@ func (r *Reg) Add(key keyDID, value ...string) {
 	r.r[key] = value
 }
 
-func initFile(filename string) (err error) {
-	if filename == "" {
-		return
-	}
-	_, err = os.Stat(filename)
-	if os.IsNotExist(err) {
-		err = writeJSONFile(filename, []byte("{}"))
-	}
-	return
-}
-
 func (r *Reg) Load(filename string) (err error) {
 	defer err2.Return(&err)
 
@@ -68,9 +57,11 @@ func (r *Reg) Load(filename string) (err error) {
 		return nil
 	}
 
-	err2.Check(initFile(filename))
-
 	data, err := readJSONFile(filename)
+	if err != nil && os.IsNotExist(err) {
+		err2.Check(writeJSONFile(filename, []byte("{}")))
+		data, err = readJSONFile(filename)
+	}
 	err2.Check(err)
 
 	r.r = *newReg(data)


### PR DESCRIPTION
* Attempt to tackle read register delay in agency startup.
* Log caDID when wallet key is not found