### PR TITLE
Add manual trigger to interop workflow.

### DIFF
--- a/.github/workflows/iop.yml
+++ b/.github/workflows/iop.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "dev"
+  workflow_dispatch:
 
 jobs:
   iop:


### PR DESCRIPTION
Let's add manual trigger to interop workflow so that any branch can be easily interop-tested through GitHub UI.