### PR TITLE
Handle routing keys when packing DIDComm messages

### DIFF
--- a/agent/aries/msg.go
+++ b/agent/aries/msg.go
@@ -134,10 +134,6 @@ func (m *msgImpl) SetInvitation(i *didexchange.Invitation) {
 	panic("not in use in old API messages")
 }
 
-func (m *msgImpl) SetSubMsg(sm map[string]interface{}) {
-	m.Msg.Msg = sm
-}
-
 func (m *msgImpl) SetDid(s string) {
 	m.Msg.Did = s
 }
@@ -221,10 +217,6 @@ func (m *msgImpl) Name() string {
 	return m.Msg.Name
 }
 
-func (m *msgImpl) SubMsg() map[string]interface{} {
-	return m.Msg.Msg
-}
-
 func (m *msgImpl) ReceiverEP() service.Addr {
 	return service.Addr{
 		Endp: m.RcvrEndp,
@@ -238,18 +230,18 @@ type Msg struct {
 
 	Thread *decorator.Thread `json:"~thread,omitempty"`
 
-	Error      string                 `json:"error,omitempty"`        // If error happens includes error msg
-	Did        string                 `json:"did,omitempty"`          // Usually senders DID and corresponding VerKey
-	VerKey     string                 `json:"verkey,omitempty"`       // Senders Verkey for DID
-	RcvrEndp   string                 `json:"rcvr_endp,omitempty"`    // Receivers own endpoint, usually the public URL
-	RcvrKey    string                 `json:"rcvr_key,omitempty"`     // Receiver endpoint ver key
-	Endpoint   string                 `json:"endpoint,omitempty"`     // Multipurpose field which still is under design
-	EndpVerKey string                 `json:"endp_ver_key,omitempty"` // VerKey associated to endpoint i.e. payload verkey
-	Name       string                 `json:"name,omitempty"`         // Multipurpose field which still is under design
-	Info       string                 `json:"info,omitempty"`         // Used for transferring additional info like the Msg in IM-cases, and Pairwise name
-	ID         string                 `json:"id,omitempty"`           // Used for transferring additional ID like the Cred Def ID
-	Ready      bool                   `json:"ready,omitempty"`        // In queries tells if something is ready when true
-	Msg        map[string]interface{} `json:"msg,omitempty"`          // Generic sub message to transport JSON between Indy SDK and EAs
+	Error      string `json:"error,omitempty"`        // If error happens includes error msg
+	Did        string `json:"did,omitempty"`          // Usually senders DID and corresponding VerKey
+	VerKey     string `json:"verkey,omitempty"`       // Senders Verkey for DID
+	RcvrEndp   string `json:"rcvr_endp,omitempty"`    // Receivers own endpoint, usually the public URL
+	RcvrKey    string `json:"rcvr_key,omitempty"`     // Receiver endpoint ver key
+	Endpoint   string `json:"endpoint,omitempty"`     // Multipurpose field which still is under design
+	EndpVerKey string `json:"endp_ver_key,omitempty"` // VerKey associated to endpoint i.e. payload verkey
+	Name       string `json:"name,omitempty"`         // Multipurpose field which still is under design
+	Info       string `json:"info,omitempty"`         // Used for transferring additional info like the Msg in IM-cases, and Pairwise name
+	ID         string `json:"id,omitempty"`           // Used for transferring additional ID like the Cred Def ID
+	Ready      bool   `json:"ready,omitempty"`        // In queries tells if something is ready when true
+	Msg        []byte `json:"msg,omitempty"`          // Forwarded message
 }
 
 func newMsg(data []byte) *msgImpl {

--- a/agent/aries/msg.go
+++ b/agent/aries/msg.go
@@ -230,18 +230,18 @@ type Msg struct {
 
 	Thread *decorator.Thread `json:"~thread,omitempty"`
 
-	Error      string `json:"error,omitempty"`        // If error happens includes error msg
-	Did        string `json:"did,omitempty"`          // Usually senders DID and corresponding VerKey
-	VerKey     string `json:"verkey,omitempty"`       // Senders Verkey for DID
-	RcvrEndp   string `json:"rcvr_endp,omitempty"`    // Receivers own endpoint, usually the public URL
-	RcvrKey    string `json:"rcvr_key,omitempty"`     // Receiver endpoint ver key
-	Endpoint   string `json:"endpoint,omitempty"`     // Multipurpose field which still is under design
-	EndpVerKey string `json:"endp_ver_key,omitempty"` // VerKey associated to endpoint i.e. payload verkey
-	Name       string `json:"name,omitempty"`         // Multipurpose field which still is under design
-	Info       string `json:"info,omitempty"`         // Used for transferring additional info like the Msg in IM-cases, and Pairwise name
-	ID         string `json:"id,omitempty"`           // Used for transferring additional ID like the Cred Def ID
-	Ready      bool   `json:"ready,omitempty"`        // In queries tells if something is ready when true
-	Msg        []byte `json:"msg,omitempty"`          // Forwarded message
+	Error      string                 `json:"error,omitempty"`        // If error happens includes error msg
+	Did        string                 `json:"did,omitempty"`          // Usually senders DID and corresponding VerKey
+	VerKey     string                 `json:"verkey,omitempty"`       // Senders Verkey for DID
+	RcvrEndp   string                 `json:"rcvr_endp,omitempty"`    // Receivers own endpoint, usually the public URL
+	RcvrKey    string                 `json:"rcvr_key,omitempty"`     // Receiver endpoint ver key
+	Endpoint   string                 `json:"endpoint,omitempty"`     // Multipurpose field which still is under design
+	EndpVerKey string                 `json:"endp_ver_key,omitempty"` // VerKey associated to endpoint i.e. payload verkey
+	Name       string                 `json:"name,omitempty"`         // Multipurpose field which still is under design
+	Info       string                 `json:"info,omitempty"`         // Used for transferring additional info like the Msg in IM-cases, and Pairwise name
+	ID         string                 `json:"id,omitempty"`           // Used for transferring additional ID like the Cred Def ID
+	Ready      bool                   `json:"ready,omitempty"`        // In queries tells if something is ready when true
+	Msg        map[string]interface{} `json:"msg,omitempty"`          // Forwarded message
 }
 
 func newMsg(data []byte) *msgImpl {

--- a/agent/cloud/agent.go
+++ b/agent/cloud/agent.go
@@ -187,26 +187,27 @@ func (a *Agent) CAEndp() (endP *endp.Addr) {
 	}
 }
 
-func (a *Agent) PwPipe(pw string) (cp sec.Pipe, err error) {
+func (a *Agent) PwPipe(pwName string) (cp sec.Pipe, err error) {
 	defer err2.Return(&err)
 
 	a.pwLock.Lock()
 	defer a.pwLock.Unlock()
 
-	if secPipe, ok := a.pwNames[pw]; ok {
+	if secPipe, ok := a.pwNames[pwName]; ok {
 		return secPipe, nil
 	}
 
-	in, out, err := a.FindPWByName(pw)
+	pw, err := a.FindPWByName(pwName)
 	err2.Check(err)
 
-	if in == "" || out == "" {
+	if pw == nil || pw.MyDID == "" || pw.TheirDID == "" {
 		return cp, errors.New("cannot find pw")
 	}
 
-	cp.In = a.LoadDID(in)
-	outDID := a.LoadDID(out)
+	cp.In = a.LoadDID(pw.MyDID)
+	outDID := a.LoadDID(pw.TheirDID)
 	outDID.StartEndp(a.Wallet())
+	outDID.SetPairwise(pw.Meta)
 	cp.Out = outDID
 	return cp, nil
 }
@@ -335,8 +336,10 @@ func (a *Agent) loadPWMap() {
 	defer a.pwLock.Unlock()
 
 	for _, d := range pwd {
-		outDID := a.LoadDID(d.TheirDid)
+		pwData := ssi.FromIndyPairwise(d)
+		outDID := a.LoadDID(pwData.TheirDID)
 		outDID.StartEndp(a.Wallet())
+		outDID.SetPairwise(pwData.Meta)
 		p := sec.Pipe{
 			In:  a.LoadDID(d.MyDid),
 			Out: outDID,

--- a/agent/cloud/agent.go
+++ b/agent/cloud/agent.go
@@ -205,9 +205,8 @@ func (a *Agent) PwPipe(pwName string) (cp sec.Pipe, err error) {
 	}
 
 	cp.In = a.LoadDID(pw.MyDID)
-	outDID := a.LoadDID(pw.TheirDID)
+	outDID := a.LoadTheirDID(*pw)
 	outDID.StartEndp(a.Wallet())
-	outDID.SetPairwise(pw.Meta)
 	cp.Out = outDID
 	return cp, nil
 }
@@ -337,9 +336,8 @@ func (a *Agent) loadPWMap() {
 
 	for _, d := range pwd {
 		pwData := ssi.FromIndyPairwise(d)
-		outDID := a.LoadDID(pwData.TheirDID)
+		outDID := a.LoadTheirDID(pwData)
 		outDID.StartEndp(a.Wallet())
-		outDID.SetPairwise(pwData.Meta)
 		p := sec.Pipe{
 			In:  a.LoadDID(d.MyDid),
 			Out: outDID,

--- a/agent/comm/receiver.go
+++ b/agent/comm/receiver.go
@@ -20,7 +20,7 @@ type Receiver interface {
 	PwPipe(pw string) (cp sec.Pipe, err error)
 	Wallet() int
 	Pool() int
-	FindPWByDID(my string) (their string, pwname string, err error)
+	FindPWByDID(my string) (pw *ssi.Pairwise, err error)
 	AttachSAImpl(implID string)
 	AddToPWMap(me, you *ssi.DID, name string) sec.Pipe
 	SaveTheirDID(did, vk string) (err error)

--- a/agent/comm/receiver.go
+++ b/agent/comm/receiver.go
@@ -16,6 +16,7 @@ type Receiver interface {
 	RootDid() *ssi.DID
 	SendNYM(targetDid *ssi.DID, submitterDid, alias, role string) (err error)
 	LoadDID(did string) *ssi.DID
+	LoadTheirDID(pw ssi.Pairwise) *ssi.DID
 	WDID() string
 	PwPipe(pw string) (cp sec.Pipe, err error)
 	Wallet() int

--- a/agent/didcomm/payload.go
+++ b/agent/didcomm/payload.go
@@ -209,14 +209,12 @@ type Msg interface {
 	SetNonce(n string)
 	SetReady(yes bool)
 	SetBody(b interface{})
-	SetSubMsg(sm map[string]interface{})
 	SetDid(s string)
 	SetVerKey(s string)
 	SetInfo(s string)
 	SetInvitation(i *didexchange.Invitation)
 
 	Ready() bool
-	SubMsg() map[string]interface{}
 }
 
 // MsgInit is a helper struct for factors to construct new message instances.
@@ -234,11 +232,10 @@ type MsgInit struct {
 	Info       string
 	ID         string
 	Ready      bool
-	Msg        map[string]interface{}
 	Thread     *decorator.Thread
 	DIDObj     *ssi.DID
 	To         string
-	MsgBytes   []byte
+	Msg        []byte
 }
 
 type MsgFactor interface {

--- a/agent/didcomm/payload.go
+++ b/agent/didcomm/payload.go
@@ -237,6 +237,8 @@ type MsgInit struct {
 	Msg        map[string]interface{}
 	Thread     *decorator.Thread
 	DIDObj     *ssi.DID
+	To         string
+	MsgBytes   []byte
 }
 
 type MsgFactor interface {

--- a/agent/didcomm/payload.go
+++ b/agent/didcomm/payload.go
@@ -235,7 +235,7 @@ type MsgInit struct {
 	Thread     *decorator.Thread
 	DIDObj     *ssi.DID
 	To         string
-	Msg        []byte
+	Msg        map[string]interface{}
 }
 
 type MsgFactor interface {

--- a/agent/pairwise/pairwise.go
+++ b/agent/pairwise/pairwise.go
@@ -30,17 +30,22 @@ type Callee struct {
 // MARK: Callee ---
 
 func (p *Callee) startStore() {
-	//log.Println("CalleePw StartStore()")
 	wallet := p.agent.Wallet()
 	p.Caller.Store(wallet)
 	pwName := p.pairwiseName()
-	req := p.Msg.FieldObj().(*didexchange.Request)
-	p.Caller.SetPairwise(ssi.PairwiseMeta{
-		Name:  pwName,
-		Route: req.Connection.DIDDoc.Service[0].RoutingKeys,
-	})
 
-	p.Callee.SavePairwiseForDID(wallet, p.Caller, pwName)
+	// Find the routing keys from the request
+	route := []string{}
+	if req, ok := p.Msg.FieldObj().(*didexchange.Request); ok {
+		route = didexchange.RouteForConnection(req.Connection)
+	} else {
+		glog.Warning("Callee.startStore() - no DIDExchange request found")
+	}
+
+	p.Callee.SavePairwiseForDID(wallet, p.Caller, ssi.PairwiseMeta{
+		Name:  pwName,
+		Route: route,
+	})
 }
 
 func (p *Callee) storeResult() error {

--- a/agent/pairwise/pairwise.go
+++ b/agent/pairwise/pairwise.go
@@ -6,6 +6,7 @@ import (
 	"github.com/findy-network/findy-agent/agent/endp"
 	"github.com/findy-network/findy-agent/agent/pltype"
 	"github.com/findy-network/findy-agent/agent/ssi"
+	"github.com/findy-network/findy-agent/std/didexchange"
 	"github.com/findy-network/findy-wrapper-go/did"
 	"github.com/golang/glog"
 	"github.com/lainio/err2"
@@ -33,6 +34,12 @@ func (p *Callee) startStore() {
 	wallet := p.agent.Wallet()
 	p.Caller.Store(wallet)
 	pwName := p.pairwiseName()
+	req := p.Msg.FieldObj().(*didexchange.Request)
+	p.Caller.SetPairwise(ssi.PairwiseMeta{
+		Name:  pwName,
+		Route: req.Connection.DIDDoc.Service[0].RoutingKeys,
+	})
+
 	p.Callee.SavePairwiseForDID(wallet, p.Caller, pwName)
 }
 

--- a/agent/pltype/pl_types.go
+++ b/agent/pltype/pl_types.go
@@ -44,6 +44,12 @@ const (
 )
 
 const (
+	ProtocolRouting      = "routing/1.0/forward"
+	RoutingForward       = Aries + "/" + ProtocolRouting
+	DIDOrgRoutingForward = DIDOrgAries + "/" + ProtocolRouting
+)
+
+const (
 	ProtocolNotification      = "notification"
 	HandlerProblemReport      = "problem-report"
 	HandlerAck                = "ack"

--- a/agent/prot/processor.go
+++ b/agent/prot/processor.go
@@ -135,9 +135,8 @@ func ContinuePSM(shift Again) (err error) {
 	err2.Check(err)
 	assert.D.True(pairwise != nil, "pairwise should not be nil")
 
-	outDID := wa.LoadDID(pairwise.TheirDID)
+	outDID := wa.LoadTheirDID(*pairwise)
 	outDID.StartEndp(wa.Wallet())
-	outDID.SetPairwise(pairwise.Meta)
 	pipe := sec.Pipe{In: inDID, Out: outDID}
 
 	sendBack := shift.SendNext != pltype.Terminate
@@ -226,10 +225,9 @@ func ExecPSM(ts Transition) (err error) {
 		err2.Check(err)
 		assert.D.True(pairwise != nil, "pairwise should not be nil")
 
-		outStr, connID := pairwise.TheirDID, pairwise.Meta.Name
-		outDID := ts.Receiver.LoadDID(outStr)
+		connID := pairwise.Meta.Name
+		outDID := ts.Receiver.LoadTheirDID(*pairwise)
 		outDID.StartEndp(ts.Receiver.Wallet())
-		outDID.SetPairwise(pairwise.Meta)
 
 		ep = sec.Pipe{In: inDID, Out: outDID}
 		im := ts.Payload.MsgHdr()

--- a/agent/psm/psm.go
+++ b/agent/psm/psm.go
@@ -217,8 +217,12 @@ func (p *PSM) PairwiseName() string {
 		if r == nil {
 			return ""
 		}
-		_, pwName := err2.StrStr.Try(r.FindPWByDID(p.ConnDID))
-		return pwName
+		pw, err := r.FindPWByDID(p.ConnDID)
+		err2.Check(err)
+
+		if pw != nil {
+			return pw.Meta.Name
+		}
 	}
 	return ""
 }

--- a/agent/sec/pipe.go
+++ b/agent/sec/pipe.go
@@ -2,6 +2,7 @@ package sec
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"time"
 
 	"github.com/findy-network/findy-agent/agent/aries"
@@ -126,10 +127,15 @@ func (p Pipe) Pack(src []byte) (dst []byte, vk string, err error) {
 	res := r.Bytes()
 	for _, rKey := range p.Out.Route() {
 		msgType := pltype.RoutingForward
+		data := make(map[string]interface{})
+		err = json.Unmarshal(res, &data)
+		if err != nil {
+			return nil, "", err
+		}
 		msg := aries.MsgCreator.Create(didcomm.MsgInit{
 			Type: msgType,
 			To:   vk,
-			Msg:  res,
+			Msg:  data,
 		})
 		fwdMsg := msg.FieldObj().(*common.Forward)
 

--- a/agent/sec/pipe.go
+++ b/agent/sec/pipe.go
@@ -129,6 +129,7 @@ func (p Pipe) Pack(src []byte) (dst []byte, vk string, err error) {
 			MsgBytes: res,
 		})
 		fwdMsg := aries.PayloadCreator.NewMsg(utils.UUID(), msgType, msg)
+		// use anon-crypt for routing
 		r := <-crypto.Pack(wallet, "", fwdMsg.JSON(), rKey)
 		if r.Err() != nil {
 			return nil, "", r.Err()

--- a/agent/sec/pipe.go
+++ b/agent/sec/pipe.go
@@ -25,10 +25,12 @@ type Pipe struct {
 
 // NewPipeByVerkey creates a new secure pipe by our DID and other end's public
 // key.
-func NewPipeByVerkey(did *ssi.DID, verkey string) *Pipe {
+func NewPipeByVerkey(did *ssi.DID, verkey string, route []string) *Pipe {
+	out := ssi.NewDid("", verkey) // we know verkey only
+	out.SetPairwise(ssi.PairwiseMeta{Route: route})
 	return &Pipe{
 		In:  did,
-		Out: ssi.NewDid("", verkey), // we know verkey only
+		Out: out,
 	}
 }
 

--- a/agent/sec/pipe.go
+++ b/agent/sec/pipe.go
@@ -28,8 +28,7 @@ type Pipe struct {
 // NewPipeByVerkey creates a new secure pipe by our DID and other end's public
 // key.
 func NewPipeByVerkey(did *ssi.DID, verkey string, route []string) *Pipe {
-	out := ssi.NewDid("", verkey) // we know verkey only
-	out.SetPairwise(ssi.PairwiseMeta{Route: route})
+	out := ssi.NewOutDid(verkey, route) // we know verkey only
 	return &Pipe{
 		In:  did,
 		Out: out,

--- a/agent/sec/pipe.go
+++ b/agent/sec/pipe.go
@@ -9,8 +9,10 @@ import (
 	"github.com/findy-network/findy-agent/agent/pltype"
 	"github.com/findy-network/findy-agent/agent/service"
 	"github.com/findy-network/findy-agent/agent/ssi"
-	"github.com/findy-network/findy-agent/agent/utils"
+	"github.com/findy-network/findy-agent/std/common"
+	"github.com/findy-network/findy-wrapper-go"
 	"github.com/findy-network/findy-wrapper-go/crypto"
+	"github.com/findy-network/findy-wrapper-go/dto"
 	"github.com/golang/glog"
 	"github.com/lainio/err2"
 )
@@ -126,13 +128,14 @@ func (p Pipe) Pack(src []byte) (dst []byte, vk string, err error) {
 	for _, rKey := range p.Out.Route() {
 		msgType := pltype.RoutingForward
 		msg := aries.MsgCreator.Create(didcomm.MsgInit{
-			Type:     msgType,
-			To:       vk,
-			MsgBytes: res,
+			Type: msgType,
+			To:   vk,
+			Msg:  res,
 		})
-		fwdMsg := aries.PayloadCreator.NewMsg(utils.UUID(), msgType, msg)
+		fwdMsg := msg.FieldObj().(*common.Forward)
+
 		// use anon-crypt for routing
-		r := <-crypto.Pack(wallet, "", fwdMsg.JSON(), rKey)
+		r := <-crypto.Pack(wallet, findy.NullString, dto.ToJSONBytes(fwdMsg), rKey)
 		if r.Err() != nil {
 			return nil, "", r.Err()
 		}

--- a/agent/sec/pipe_test.go
+++ b/agent/sec/pipe_test.go
@@ -1,0 +1,154 @@
+package sec
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/findy-network/findy-agent/agent/aries"
+	"github.com/findy-network/findy-agent/agent/pltype"
+	"github.com/findy-network/findy-agent/agent/service"
+	"github.com/findy-network/findy-agent/agent/ssi"
+	"github.com/findy-network/findy-agent/agent/utils"
+	"github.com/findy-network/findy-agent/std/common"
+	"github.com/findy-network/findy-agent/std/decorator"
+	"github.com/findy-network/findy-agent/std/did"
+	"github.com/findy-network/findy-agent/std/didexchange"
+	"github.com/lainio/err2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	setUp()
+	code := m.Run()
+	tearDown()
+	os.Exit(code)
+}
+
+func tearDown() {
+	home := utils.IndyBaseDir()
+	removeFiles(home, "/.indy_client/wallet/pipe-test-agent*")
+}
+
+func removeFiles(home, nameFilter string) {
+	filter := filepath.Join(home, nameFilter)
+	files, _ := filepath.Glob(filter)
+	for _, f := range files {
+		if err := os.RemoveAll(f); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func setUp() {
+}
+
+type packed struct {
+	Protected string
+}
+
+type protected struct {
+	Recipients []struct {
+		Header struct {
+			Kid string `json:"kid"`
+		} `json:"header"`
+	} `json:"recipients"`
+}
+
+func getRecipientKeys(msg []byte) (keys []string, err error) {
+	err2.Return(&err)
+
+	msgFields := make(map[string]interface{})
+	err2.Check(json.Unmarshal(msg, &msgFields))
+
+	protData := err2.Bytes.Try(utils.DecodeB64(msgFields["protected"].(string)))
+
+	data := protected{}
+	err2.Check(json.Unmarshal(protData, &data))
+
+	keys = make([]string, 0)
+	for _, recipient := range data.Recipients {
+		keys = append(keys, recipient.Header.Kid)
+	}
+	return keys, nil
+}
+
+func TestPipe_pack(t *testing.T) {
+	// Create test wallet and routing keys
+	walletID := fmt.Sprintf("pipe-test-agent-%d", time.Now().Unix())
+	aw := ssi.NewRawWalletCfg(walletID, "4Vwsj6Qcczmhk2Ak7H5GGvFE1cQCdRtWfW4jchahNUoE")
+	aw.Create()
+	a := ssi.DIDAgent{}
+	a.OpenWallet(*aw)
+	didIn := a.CreateDID("")
+	didOut := a.CreateDID("")
+	didRoute1 := a.CreateDID("")
+	didRoute2 := a.CreateDID("")
+
+	// Packing pipe with two routing keys
+	packPipe := NewPipeByVerkey(didIn, didOut.VerKey(), []string{didRoute1.VerKey(), didRoute2.VerKey()})
+
+	// Simulate actual aries message
+	plID := utils.UUID()
+	msg := didexchange.NewRequest(&didexchange.Request{
+		Label: "test",
+		Connection: &didexchange.Connection{
+			DID: didIn.Did(),
+			DIDDoc: did.NewDoc(didIn, service.Addr{
+				Endp: "http://example.com",
+				Key:  didIn.VerKey(),
+			}),
+		},
+		Thread: &decorator.Thread{ID: utils.UUID()},
+	})
+	pl := aries.PayloadCreator.NewMsg(plID, pltype.AriesConnectionRequest, msg)
+
+	// Pack message
+	route2bytes, _, err := packPipe.Pack(pl.JSON())
+	assert.Nil(t, err)
+	assert.True(t, len(route2bytes) > 0)
+
+	// Unpack forward message with last routing key
+	route2Keys, err := getRecipientKeys(route2bytes)
+	assert.True(t, len(route2Keys) == 1)
+	assert.Equal(t, didRoute2.VerKey(), route2Keys[0])
+
+	route1UnpackPipe := NewPipeByVerkey(didRoute2, didIn.VerKey(), []string{})
+	route1FwBytes, _, err := route1UnpackPipe.Unpack(route2bytes)
+	assert.Nil(t, err)
+
+	// Unpack next forward message with first routing key
+	route1FwdMsg := aries.PayloadCreator.NewFromData(route1FwBytes).MsgHdr().FieldObj().(*common.Forward)
+	route1Bytes := route1FwdMsg.Msg
+	route1Keys, err := getRecipientKeys(route1Bytes)
+	assert.True(t, len(route2Keys) == 1)
+	assert.Equal(t, didRoute1.VerKey(), route1Keys[0])
+	assert.Equal(t, didRoute1.VerKey(), route1FwdMsg.To)
+
+	dstUnpackPipe := NewPipeByVerkey(didOut, didIn.VerKey(), []string{})
+	dstFwBytes, _, err := dstUnpackPipe.Unpack(route1Bytes)
+	assert.Nil(t, err)
+
+	// Unpack final (anon-crypted) forward message with destination key
+	dstFwdMsg := aries.PayloadCreator.NewFromData(dstFwBytes).MsgHdr().FieldObj().(*common.Forward)
+	dstPackedBytes := dstFwdMsg.Msg
+	dstFwdKeys, err := getRecipientKeys(dstPackedBytes)
+	assert.True(t, len(dstFwdKeys) == 1)
+	assert.Equal(t, didOut.VerKey(), dstFwdKeys[0])
+	assert.Equal(t, didOut.VerKey(), dstFwdMsg.To)
+
+	// Unpack final (auth-crypted) message with destination key
+	dstBytes, _, err := dstUnpackPipe.Unpack(dstPackedBytes)
+	assert.Nil(t, err)
+	dstKeys, err := getRecipientKeys(dstPackedBytes)
+	assert.True(t, len(dstFwdKeys) == 1)
+	assert.Equal(t, didOut.VerKey(), dstKeys[0])
+
+	dstMsg := aries.PayloadCreator.NewFromData(dstBytes)
+	assert.True(t, dstMsg.MsgHdr().Type() == pltype.AriesConnectionRequest)
+	assert.True(t, dstMsg.MsgHdr().ID() == plID)
+	assert.True(t, dstMsg.MsgHdr().FieldObj().(*didexchange.Request).Label == "test")
+}

--- a/agent/sec/pipe_test.go
+++ b/agent/sec/pipe_test.go
@@ -46,10 +46,6 @@ func removeFiles(home, nameFilter string) {
 func setUp() {
 }
 
-type packed struct {
-	Protected string
-}
-
 type protected struct {
 	Recipients []struct {
 		Header struct {
@@ -113,6 +109,7 @@ func TestPipe_pack(t *testing.T) {
 
 	// Unpack forward message with last routing key
 	route2Keys, err := getRecipientKeys(route2bytes)
+	assert.Nil(t, err)
 	assert.True(t, len(route2Keys) == 1)
 	assert.Equal(t, didRoute2.VerKey(), route2Keys[0])
 
@@ -124,6 +121,7 @@ func TestPipe_pack(t *testing.T) {
 	route1FwdMsg := aries.PayloadCreator.NewFromData(route1FwBytes).MsgHdr().FieldObj().(*common.Forward)
 	route1Bytes := route1FwdMsg.Msg
 	route1Keys, err := getRecipientKeys(route1Bytes)
+	assert.Nil(t, err)
 	assert.True(t, len(route2Keys) == 1)
 	assert.Equal(t, didRoute1.VerKey(), route1Keys[0])
 	assert.Equal(t, didRoute1.VerKey(), route1FwdMsg.To)
@@ -136,6 +134,7 @@ func TestPipe_pack(t *testing.T) {
 	dstFwdMsg := aries.PayloadCreator.NewFromData(dstFwBytes).MsgHdr().FieldObj().(*common.Forward)
 	dstPackedBytes := dstFwdMsg.Msg
 	dstFwdKeys, err := getRecipientKeys(dstPackedBytes)
+	assert.Nil(t, err)
 	assert.True(t, len(dstFwdKeys) == 1)
 	assert.Equal(t, didOut.VerKey(), dstFwdKeys[0])
 	assert.Equal(t, didOut.VerKey(), dstFwdMsg.To)
@@ -144,6 +143,7 @@ func TestPipe_pack(t *testing.T) {
 	dstBytes, _, err := dstUnpackPipe.Unpack(dstPackedBytes)
 	assert.Nil(t, err)
 	dstKeys, err := getRecipientKeys(dstPackedBytes)
+	assert.Nil(t, err)
 	assert.True(t, len(dstFwdKeys) == 1)
 	assert.Equal(t, didOut.VerKey(), dstKeys[0])
 

--- a/agent/ssi/agent.go
+++ b/agent/ssi/agent.go
@@ -1,13 +1,13 @@
 package ssi
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"sync"
 
 	"github.com/findy-network/findy-agent/agent/managed"
 	"github.com/findy-network/findy-agent/agent/service"
+	"github.com/findy-network/findy-agent/agent/utils"
 	"github.com/findy-network/findy-wrapper-go/did"
 	"github.com/findy-network/findy-wrapper-go/ledger"
 	"github.com/findy-network/findy-wrapper-go/pairwise"
@@ -234,10 +234,16 @@ func (a *DIDAgent) LoadDID(did string) *DID {
 	return d
 }
 
+func (a *DIDAgent) LoadTheirDID(pw Pairwise) *DID {
+	did := a.LoadDID(pw.TheirDID)
+	did.pwMeta = &pw.Meta
+	return did
+}
+
 func FromIndyPairwise(pw pairwise.Data) Pairwise {
 	itemName := pw.Metadata
 	metaData := PairwiseMeta{}
-	bytes, err := base64.StdEncoding.DecodeString(pw.Metadata)
+	bytes, err := utils.DecodeB64(pw.Metadata)
 	if err == nil {
 		err = json.Unmarshal(bytes, &metaData) // meta data is stored to wallet as an object
 	}

--- a/agent/ssi/agent.go
+++ b/agent/ssi/agent.go
@@ -133,7 +133,7 @@ func (a *DIDAgent) assertPool() {
 }
 
 func (a *DIDAgent) OpenWallet(aw Wallet) {
-	a.WalletH = Wallets.Open(aw)
+	a.WalletH = wallets.Open(aw)
 	if glog.V(5) {
 		glog.Info("Opening wallet: ", aw.Config.ID)
 	}

--- a/agent/ssi/agent.go
+++ b/agent/ssi/agent.go
@@ -276,7 +276,7 @@ func (a *DIDAgent) FindPWByName(name string) (pw *Pairwise, err error) {
 	return nil, nil
 }
 
-// FindPWByDID finds pairwise by name. This is a ReceiverEndp interface method.
+// FindPWByDID finds pairwise by my DID. This is a ReceiverEndp interface method.
 func (a *DIDAgent) FindPWByDID(my string) (pw *Pairwise, err error) {
 	a.AssertWallet()
 	r := <-pairwise.List(a.Wallet())

--- a/agent/ssi/did.go
+++ b/agent/ssi/did.go
@@ -20,6 +20,7 @@ type DidComm interface {
 type Out interface {
 	DidComm
 	VerKey() string
+	Route() []string
 	Endpoint() string                      // refactor
 	AEndp() (ae service.Addr, error error) // refactor
 }
@@ -213,4 +214,8 @@ func (d *DID) AEndp() (ae service.Addr, err error) {
 		return service.Addr{Endp: endP, Key: vk}, nil
 	}
 	return service.Addr{}, fmt.Errorf("no data")
+}
+
+func (d *DID) Route() []string {
+	return []string{}
 }

--- a/agent/ssi/walletmgr.go
+++ b/agent/ssi/walletmgr.go
@@ -15,8 +15,8 @@ var maxOpened = 10
 // the same time. This should be set at the startup of the application or
 // service.
 func SetWalletMgrPoolSize(s int) {
-	Wallets.l.Lock() // Precaution
-	defer Wallets.l.Unlock()
+	wallets.l.Lock() // Precaution
+	defer wallets.l.Unlock()
 
 	maxOpened = s
 }
@@ -83,7 +83,7 @@ func (h *Handle) Handle() int {
 	}
 
 	// reopen with the Manager. Note! They know that handle is locked
-	return Wallets.reopen(h)
+	return wallets.reopen(h)
 }
 
 // reopen opens the wallet by its configuration. Open is always called by Wallet
@@ -105,7 +105,7 @@ type Mgr struct {
 	l      sync.Mutex // lock
 }
 
-var Wallets = &Mgr{
+var wallets = &Mgr{
 	opened: make(WalletMap, maxOpened),
 }
 

--- a/agent/ssi/walletmgr_test.go
+++ b/agent/ssi/walletmgr_test.go
@@ -67,7 +67,7 @@ func TestMgr_NewOpen(t *testing.T) {
 		SetWalletMgrPoolSize(tt.count)
 
 		cfg := *NewRawWalletCfg(walletName1, key)
-		w := Wallets.Open(cfg)
+		w := wallets.Open(cfg)
 		glog.V(3).Info("read handle 1")
 		assert.Greater(t, w.Handle(), 0)
 
@@ -79,7 +79,7 @@ func TestMgr_NewOpen(t *testing.T) {
 		cfg = *NewRawWalletCfg(walletName2, key)
 		time.Sleep(time.Nanosecond) // 'real' work for underlying algorithm
 
-		w2 := Wallets.Open(cfg)
+		w2 := wallets.Open(cfg)
 		glog.V(3).Info("read handle 2")
 		assert.Greater(t, w2.Handle(), 0)
 
@@ -97,7 +97,7 @@ func TestMgr_NewOpen(t *testing.T) {
 
 		cfg = *NewRawWalletCfg(walletName3, key)
 		time.Sleep(time.Nanosecond) // 'real' work for underlying algorithm
-		w3 := Wallets.Open(cfg)
+		w3 := wallets.Open(cfg)
 		glog.V(3).Info("read handle 3")
 		assert.Greater(t, w3.Handle(), 0)
 
@@ -106,6 +106,6 @@ func TestMgr_NewOpen(t *testing.T) {
 		w2.Handle()
 		w2.Handle()
 
-		Wallets.Reset()
+		wallets.Reset()
 	}
 }

--- a/agent/utils/base64.go
+++ b/agent/utils/base64.go
@@ -1,0 +1,11 @@
+package utils
+
+import "encoding/base64"
+
+func DecodeB64(str string) ([]byte, error) {
+	data, err := base64.URLEncoding.DecodeString(str)
+	if err != nil {
+		data, err = base64.RawURLEncoding.DecodeString(str)
+	}
+	return data, err
+}

--- a/agent/utils/base64_test.go
+++ b/agent/utils/base64_test.go
@@ -1,4 +1,4 @@
-package didexchange
+package utils
 
 import (
 	"reflect"
@@ -9,12 +9,12 @@ func TestDecodeB64(t *testing.T) {
 	const strPadded = "c3VyZS4="
 	const strUnpadded = "c3VyZS4"
 
-	res1, err := decodeB64(strPadded)
+	res1, err := DecodeB64(strPadded)
 	if err != nil {
 		t.Errorf("error in padded decode = %v", err)
 	}
 
-	res2, err := decodeB64(strUnpadded)
+	res2, err := DecodeB64(strUnpadded)
 	if err != nil {
 		t.Errorf("error in unpadded decode = %v", err)
 	}

--- a/protocol/basicmessage/basic_message_protocol.go
+++ b/protocol/basicmessage/basic_message_protocol.go
@@ -96,13 +96,15 @@ func handleBasicMessage(packet comm.Packet) (err error) {
 	tHandler := func(connID string, im, om didcomm.MessageHdr) (ack bool, err error) {
 		defer err2.Annotate("basic message", &err)
 
-		_, name := err2.StrStr.Try(packet.Receiver.FindPWByDID(packet.Address.RcvrDID))
+		pw, err := packet.Receiver.FindPWByDID(packet.Address.RcvrDID)
+		err2.Check(err)
+		assert.D.True(pw != nil, "pairwise is nil")
 
 		bm := im.FieldObj().(*basicmessage.Basicmessage)
 
 		if glog.V(3) {
 			glog.Info("-- Thread id: ", im.Thread().ID)
-			glog.Info("Basic msg from:", name)
+			glog.Info("Basic msg from:", pw.Meta.Name)
 			glog.Info("Sent time:", bm.SentTime)
 			glog.Info("Content: ", bm.Content)
 		}
@@ -114,7 +116,7 @@ func handleBasicMessage(packet comm.Packet) (err error) {
 
 		rep := &basicMessageRep{
 			StateKey:      key,
-			PwName:        name,
+			PwName:        pw.Meta.Name,
 			Message:       bm.Content,
 			SendTimestamp: bm.SentTime.Time.UnixNano(),
 			Timestamp:     time.Now().UnixNano(),

--- a/protocol/connection/connection_protocol.go
+++ b/protocol/connection/connection_protocol.go
@@ -153,7 +153,7 @@ func startConnectionProtocol(ca comm.Receiver, task comm.Task) {
 
 	// Create secure pipe to send payload to other end of the new PW
 	receiverKey := task.ReceiverEndp().Key
-	secPipe := sec.NewPipeByVerkey(caller, receiverKey)
+	secPipe := sec.NewPipeByVerkey(caller, receiverKey, deTask.Invitation.RoutingKeys)
 	wa.AddPipeToPWMap(*secPipe, pwr.Name)
 
 	// Update PSM state, and send the payload to other end
@@ -327,6 +327,11 @@ func handleConnectionResponse(packet comm.Packet) (err error) {
 
 	pwName := pwr.Name
 
+	resp := ipl.MsgHdr().FieldObj().(*didexchange.Response)
+	callee.SetPairwise(ssi.PairwiseMeta{
+		Name:  pwName,
+		Route: resp.Connection.DIDDoc.Service[0].RoutingKeys,
+	})
 	caller.SavePairwiseForDID(a.Wallet(), callee, pwName)
 
 	// SAVE ENDPOINT to wallet

--- a/protocol/connection/connection_protocol.go
+++ b/protocol/connection/connection_protocol.go
@@ -20,6 +20,7 @@ import (
 	"github.com/findy-network/findy-agent/std/decorator"
 	diddoc "github.com/findy-network/findy-agent/std/did"
 	"github.com/findy-network/findy-agent/std/didexchange"
+	"github.com/findy-network/findy-agent/std/didexchange/signature"
 	pb "github.com/findy-network/findy-common-go/grpc/agency/v1"
 	"github.com/findy-network/findy-common-go/std/didexchange/invitation"
 	"github.com/findy-network/findy-wrapper-go/did"
@@ -268,7 +269,7 @@ func handleConnectionRequest(packet comm.Packet) (err error) {
 		Out: caller,          // This is the other end, who sent the Request
 	}
 
-	err2.Check(res.Sign(pipe)) // we must sign the Response before send it
+	err2.Check(signature.Sign(res, pipe)) // we must sign the Response before send it
 
 	caller.SetAEndp(IncomingPWMsg.Endpoint())
 	a.AddToPWMap(calleePw.Callee, caller, connectionID) // to access PW later, map it
@@ -296,7 +297,7 @@ func handleConnectionResponse(packet comm.Packet) (err error) {
 
 	nonce := ipl.ThreadID()
 	response := ipl.MsgHdr().FieldObj().(*didexchange.Response)
-	if !err2.Bool.Try(response.Verify()) {
+	if !err2.Bool.Try(signature.Verify(response)) {
 		glog.Error("cannot verify Connection Response signature --> send NACK")
 		return errors.New("cannot verify connection response signature")
 		// todo: send NACK here

--- a/protocol/connection/connection_protocol.go
+++ b/protocol/connection/connection_protocol.go
@@ -327,13 +327,11 @@ func handleConnectionResponse(packet comm.Packet) (err error) {
 	callee.Store(a.Wallet())
 
 	pwName := pwr.Name
-
-	resp := ipl.MsgHdr().FieldObj().(*didexchange.Response)
-	callee.SetPairwise(ssi.PairwiseMeta{
+	route := didexchange.RouteForConnection(response.Connection)
+	caller.SavePairwiseForDID(a.Wallet(), callee, ssi.PairwiseMeta{
 		Name:  pwName,
-		Route: resp.Connection.DIDDoc.Service[0].RoutingKeys,
+		Route: route,
 	})
-	caller.SavePairwiseForDID(a.Wallet(), callee, pwName)
 
 	// SAVE ENDPOINT to wallet
 	calleeEndp := endp.NewAddrFromPublic(im.Endpoint())

--- a/std/common/forward.go
+++ b/std/common/forward.go
@@ -1,0 +1,16 @@
+/*
+copied from aries-framework-go
+
+*/
+
+package common
+
+// Forward route forward message.
+// nolint:lll // url in the next line is long
+// https://github.com/hyperledger/aries-rfcs/blob/main/concepts/0094-cross-domain-messaging/README.md#corerouting10forward
+type Forward struct {
+	Type string `json:"@type,omitempty"`
+	ID   string `json:"@id,omitempty"`
+	To   string `json:"to,omitempty"`
+	Msg  []byte `json:"msg,omitempty"`
+}

--- a/std/common/forward.go
+++ b/std/common/forward.go
@@ -9,8 +9,8 @@ package common
 // nolint:lll // url in the next line is long
 // https://github.com/hyperledger/aries-rfcs/blob/main/concepts/0094-cross-domain-messaging/README.md#corerouting10forward
 type Forward struct {
-	Type string `json:"@type,omitempty"`
-	ID   string `json:"@id,omitempty"`
-	To   string `json:"to,omitempty"`
-	Msg  []byte `json:"msg,omitempty"`
+	Type string                 `json:"@type,omitempty"`
+	ID   string                 `json:"@id,omitempty"`
+	To   string                 `json:"to,omitempty"`
+	Msg  map[string]interface{} `json:"msg,omitempty"`
 }

--- a/std/common/forward_impl.go
+++ b/std/common/forward_impl.go
@@ -1,0 +1,80 @@
+package common
+
+import (
+	"encoding/gob"
+
+	"github.com/findy-network/findy-agent/agent/aries"
+	"github.com/findy-network/findy-agent/agent/didcomm"
+	"github.com/findy-network/findy-agent/agent/pltype"
+	"github.com/findy-network/findy-agent/std/decorator"
+	"github.com/findy-network/findy-wrapper-go/dto"
+	"github.com/lainio/err2/assert"
+)
+
+var ForwardCreator = &ForwardFactor{}
+
+type ForwardFactor struct{}
+
+func (f *ForwardFactor) NewMsg(init didcomm.MsgInit) didcomm.MessageHdr {
+	m := &Forward{
+		Type: init.Type,
+		ID:   init.AID,
+		To:   init.To,
+		Msg:  init.MsgBytes,
+	}
+	return NewForward(m)
+}
+
+func (f *ForwardFactor) NewMessage(data []byte) didcomm.MessageHdr {
+	return NewForwardMsg(data)
+}
+
+func init() {
+	gob.Register(&ForwardImpl{})
+	aries.Creator.Add(pltype.RoutingForward, ForwardCreator)
+	aries.Creator.Add(pltype.DIDOrgRoutingForward, ForwardCreator)
+}
+
+func NewForward(r *Forward) *ForwardImpl {
+	return &ForwardImpl{Forward: r}
+}
+
+func NewForwardMsg(data []byte) *ForwardImpl {
+	var mImpl ForwardImpl
+	dto.FromJSON(data, &mImpl)
+	return &mImpl
+}
+
+// MARK: Struct
+type ForwardImpl struct {
+	*Forward
+}
+
+func (p *ForwardImpl) ID() string {
+	return p.Forward.ID
+}
+
+func (p *ForwardImpl) Type() string {
+	return p.Forward.Type
+}
+
+func (p *ForwardImpl) SetID(id string) {
+	p.Forward.ID = id
+}
+
+func (p *ForwardImpl) SetType(t string) {
+	p.Forward.Type = t
+}
+
+func (p *ForwardImpl) JSON() []byte {
+	return dto.ToJSONBytes(p)
+}
+
+func (p *ForwardImpl) Thread() *decorator.Thread {
+	assert.D.True(false, "Should not be here")
+	return nil
+}
+
+func (p *ForwardImpl) FieldObj() interface{} {
+	return p.Forward
+}

--- a/std/common/forward_impl.go
+++ b/std/common/forward_impl.go
@@ -22,11 +22,11 @@ func (f *forwardFactor) NewMsg(init didcomm.MsgInit) didcomm.MessageHdr {
 		To:   init.To,
 		Msg:  init.Msg,
 	}
-	return NewForward(m)
+	return newForward(m)
 }
 
 func (f *forwardFactor) NewMessage(data []byte) didcomm.MessageHdr {
-	return NewForwardMsg(data)
+	return newForwardMsg(data)
 }
 
 func init() {
@@ -35,11 +35,11 @@ func init() {
 	aries.Creator.Add(pltype.DIDOrgRoutingForward, forwardCreator)
 }
 
-func NewForward(r *Forward) *forwardImpl {
+func newForward(r *Forward) *forwardImpl {
 	return &forwardImpl{Forward: r}
 }
 
-func NewForwardMsg(data []byte) *forwardImpl {
+func newForwardMsg(data []byte) *forwardImpl {
 	var mImpl forwardImpl
 	dto.FromJSON(data, &mImpl)
 	return &mImpl

--- a/std/common/forward_impl.go
+++ b/std/common/forward_impl.go
@@ -11,70 +11,70 @@ import (
 	"github.com/lainio/err2/assert"
 )
 
-var ForwardCreator = &ForwardFactor{}
+var forwardCreator = &forwardFactor{}
 
-type ForwardFactor struct{}
+type forwardFactor struct{}
 
-func (f *ForwardFactor) NewMsg(init didcomm.MsgInit) didcomm.MessageHdr {
+func (f *forwardFactor) NewMsg(init didcomm.MsgInit) didcomm.MessageHdr {
 	m := &Forward{
 		Type: init.Type,
 		ID:   init.AID,
 		To:   init.To,
-		Msg:  init.MsgBytes,
+		Msg:  init.Msg,
 	}
 	return NewForward(m)
 }
 
-func (f *ForwardFactor) NewMessage(data []byte) didcomm.MessageHdr {
+func (f *forwardFactor) NewMessage(data []byte) didcomm.MessageHdr {
 	return NewForwardMsg(data)
 }
 
 func init() {
-	gob.Register(&ForwardImpl{})
-	aries.Creator.Add(pltype.RoutingForward, ForwardCreator)
-	aries.Creator.Add(pltype.DIDOrgRoutingForward, ForwardCreator)
+	gob.Register(&forwardImpl{})
+	aries.Creator.Add(pltype.RoutingForward, forwardCreator)
+	aries.Creator.Add(pltype.DIDOrgRoutingForward, forwardCreator)
 }
 
-func NewForward(r *Forward) *ForwardImpl {
-	return &ForwardImpl{Forward: r}
+func NewForward(r *Forward) *forwardImpl {
+	return &forwardImpl{Forward: r}
 }
 
-func NewForwardMsg(data []byte) *ForwardImpl {
-	var mImpl ForwardImpl
+func NewForwardMsg(data []byte) *forwardImpl {
+	var mImpl forwardImpl
 	dto.FromJSON(data, &mImpl)
 	return &mImpl
 }
 
 // MARK: Struct
-type ForwardImpl struct {
+type forwardImpl struct {
 	*Forward
 }
 
-func (p *ForwardImpl) ID() string {
+func (p *forwardImpl) ID() string {
 	return p.Forward.ID
 }
 
-func (p *ForwardImpl) Type() string {
+func (p *forwardImpl) Type() string {
 	return p.Forward.Type
 }
 
-func (p *ForwardImpl) SetID(id string) {
+func (p *forwardImpl) SetID(id string) {
 	p.Forward.ID = id
 }
 
-func (p *ForwardImpl) SetType(t string) {
+func (p *forwardImpl) SetType(t string) {
 	p.Forward.Type = t
 }
 
-func (p *ForwardImpl) JSON() []byte {
+func (p *forwardImpl) JSON() []byte {
 	return dto.ToJSONBytes(p)
 }
 
-func (p *ForwardImpl) Thread() *decorator.Thread {
+func (p *forwardImpl) Thread() *decorator.Thread {
 	assert.D.True(false, "Should not be here")
 	return nil
 }
 
-func (p *ForwardImpl) FieldObj() interface{} {
+func (p *forwardImpl) FieldObj() interface{} {
 	return p.Forward
 }

--- a/std/common/forward_test.go
+++ b/std/common/forward_test.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/findy-network/findy-agent/agent/aries"
+	"github.com/stretchr/testify/assert"
+)
+
+var forwardJSON = `
+  {
+    "@type": "https://didcomm.org/routing/1.0/forward",
+    "@id": "54ad1a63-29bd-4a59-abed-1c5b1026e6fd",
+    "to": "did:sov:1234abcd#4"
+  }`
+
+func TestForward_ReadJSON(t *testing.T) {
+	ipl := aries.PayloadCreator.NewFromData([]byte(forwardJSON))
+
+	assert.Equal(t, "54ad1a63-29bd-4a59-abed-1c5b1026e6fd", ipl.ID())
+
+	msg, ok := ipl.MsgHdr().FieldObj().(*Forward)
+	assert.True(t, ok)
+	assert.Equal(t, "did:sov:1234abcd#4", msg.To)
+}

--- a/std/didexchange/models.go
+++ b/std/didexchange/models.go
@@ -49,15 +49,15 @@ type Connection struct {
 
 func RouteForConnection(conn *Connection) (route []string) {
 	// Find the routing keys from the request
-	if conn != nil {
-		if conn != nil && conn.DIDDoc != nil {
-			assert.D.True(len(conn.DIDDoc.Service) > 0)
-			route = conn.DIDDoc.Service[0].RoutingKeys
-		} else {
-			glog.Warning("RouteForConnection - request does not contain DIDDoc")
-		}
-	} else {
-		glog.Warning("RouteForConnection - no DIDExchange request found")
+	if conn == nil {
+		glog.Warningln("RouteForConnection - no DIDExchange request found")
+		return
 	}
-	return route
+	if conn.DIDDoc == nil {
+		glog.Warningln("RouteForConnection - request does not contain DIDDoc")
+		return
+	}
+	assert.D.True(len(conn.DIDDoc.Service) > 0)
+	route = conn.DIDDoc.Service[0].RoutingKeys
+	return
 }

--- a/std/didexchange/models.go
+++ b/std/didexchange/models.go
@@ -8,6 +8,8 @@ package didexchange
 import (
 	"github.com/findy-network/findy-agent/std/decorator"
 	"github.com/findy-network/findy-agent/std/did"
+	"github.com/golang/glog"
+	"github.com/lainio/err2/assert"
 )
 
 // Request defines a2a DID exchange request
@@ -43,4 +45,19 @@ type ConnectionSignature struct {
 type Connection struct {
 	DID    string   `json:"DID,omitempty"`
 	DIDDoc *did.Doc `json:"DIDDoc,omitempty"` // todo: was did_doc
+}
+
+func RouteForConnection(conn *Connection) (route []string) {
+	// Find the routing keys from the request
+	if conn != nil {
+		if conn != nil && conn.DIDDoc != nil {
+			assert.D.True(len(conn.DIDDoc.Service) > 0)
+			route = conn.DIDDoc.Service[0].RoutingKeys
+		} else {
+			glog.Warning("RouteForConnection - request does not contain DIDDoc")
+		}
+	} else {
+		glog.Warning("RouteForConnection - no DIDExchange request found")
+	}
+	return route
 }

--- a/std/didexchange/response.go
+++ b/std/didexchange/response.go
@@ -1,28 +1,8 @@
 package didexchange
 
 import (
-	"strings"
-
-	"github.com/findy-network/findy-agent/agent/sec"
 	"github.com/findy-network/findy-agent/agent/service"
 )
-
-func (r *Response) Sign(pipe sec.Pipe) (err error) {
-	r.ConnectionSignature, err = r.Connection.buildConnectionSignature(pipe)
-	return err
-}
-
-func (r *Response) Verify() (ok bool, err error) {
-	r.Connection, err = r.ConnectionSignature.verifySignature(nil)
-	ok = r.Connection != nil
-
-	if ok {
-		rawDID := r.Connection.DIDDoc.ID
-		r.Connection.DID = strings.TrimPrefix(rawDID, "did:sov:")
-	}
-
-	return ok, err
-}
 
 func (r *Response) Endpoint() service.Addr {
 	if len(r.Connection.DIDDoc.Service) == 0 {


### PR DESCRIPTION
If the other end of the pairwise connection provides routing keys during the connection protocol, use the routing keys to generate a nested forward-message structure while packing the message contents:

* Additional packing logic implemented to `sec.Pipe`
* Routing keys are stored with the pairwise name to indy-wallet pairwise meta data field. Previously the field was only the pairwise name as string, now the meta data is stored as a JSON object with multiple fields. To avoid problems with indy/wrapper JSON decoding, the meta JSON object is stored as base64-encoded string. Conversion logic from existing pairwise instances should be in place (though routing keys can be added only to new pairwise connections).