### PR TITLE
Adding missing request timeout env and no register backup if empty

### DIFF
--- a/agent/agency/register.go
+++ b/agent/agency/register.go
@@ -55,7 +55,13 @@ func Backup() {
 		glog.Warning(err)
 	})
 
-	name := backupName(utils.Settings.RegisterBackupName())
+	backupFileName := utils.Settings.RegisterBackupName()
+	if backupFileName == "" {
+		glog.V(10).Infoln("register backup name is empty, will not backup")
+		return
+	}
+
+	name := backupName(backupFileName)
 	err2.Check(backup.FileCopy(utils.Settings.RegisterName(), name))
 	glog.V(1).Infoln("CA register backup successful to:", name)
 	lastBackup = time.Now()

--- a/cmd/agency.go
+++ b/cmd/agency.go
@@ -53,6 +53,7 @@ var agencyStartEnvs = map[string]string{
 	"wallet-backup":            "WALLET_BACKUP",
 	"wallet-backup-time":       "WALLET_BACKUP_TIME",
 	"wallet-pool":              "WALLET_POOL",
+	"request-timeout":          "REQUEST_TIMEOUT",
 }
 
 // startAgencyCmd represents the agency start subcommand


### PR DESCRIPTION
- follow startup args in server mode, i.e. no register backup if filename is set to empty
- adding missing information to get env `FCLI_REQUEST_TIMEOUT` working which is used in `scripts/deploy/Dockerfile`