### PR TITLE
Skip connection response timestamp verification for now.

### DIFF
--- a/std/didexchange/signature/signature.go
+++ b/std/didexchange/signature/signature.go
@@ -106,10 +106,12 @@ func verifySignature(cs *didexchange.ConnectionSignature, pipe *sec.Pipe) (c *di
 	timestamp, ok := verifyTimestamp(data)
 	if !ok {
 		glog.Errorln("connection signature timestamp is invalid: ", timestamp, time.Unix(timestamp, 0))
-		return nil, nil
+		// TODO: pass invalid timestamps on for now, as some agents do not fill it at all
+		// should be fixed with new signature implementation
+		// return nil, nil
+	} else {
+		glog.V(3).Info("verified connection signature w/ ts:", time.Unix(timestamp, 0))
 	}
-
-	glog.V(3).Info("verified connection signature w/ ts:", time.Unix(timestamp, 0))
 
 	connectionJSON := data[8:]
 


### PR DESCRIPTION
It seems the new logic for response timestamp verification broke the interoperability tests with javascript-agent: as javascript-agent does not send a valid timestamp with the response, timestamp verification fails and connection is not established. Instead, an error occurs and because we are missing NACK-sending to the other end, the tests are left pending (counterparty does not receive any message).

The timestamp validation logic worked before with the javascript-agent because the diff minimum value was not checked (negative values were passed).

Thus, suggesting we skip the timestamp validation for now, and get back to this when we implement the new signature specification.