### PR TITLE
Fix mixup between hash and encrypt functions.

### DIFF
--- a/agent/psm/db.go
+++ b/agent/psm/db.go
@@ -69,11 +69,11 @@ func addData(key []byte, value []byte, bucketID byte) (err error) {
 	return mgdDB.AddKeyValueToBucket(buckets[bucketID],
 		&db.Data{
 			Data: value,
-			Read: hash,
+			Read: encrypt,
 		},
 		&db.Data{
 			Data: key,
-			Read: encrypt,
+			Read: hash,
 		},
 	)
 }

--- a/agent/psm/db_test.go
+++ b/agent/psm/db_test.go
@@ -1,20 +1,24 @@
 package psm
 
 import (
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"os"
 	"testing"
 
+	"github.com/findy-network/findy-common-go/crypto"
 	"github.com/findy-network/findy-common-go/crypto/db"
 	"github.com/findy-network/findy-common-go/dto"
 	"github.com/go-test/deep"
 	"github.com/lainio/err2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
-	dbPath = "db_test.bolt"
+	dbPath  = "db_test.bolt"
+	testKey = "15308490f1e4026284594dd08d31291bc8ef2aeac730d0daf6ff87bb92d4336c"
 )
 
 func TestMain(m *testing.M) {
@@ -45,13 +49,21 @@ func Test_addPSM(t *testing.T) {
 	psm := testPSM(0)
 	assert.NotNil(t, psm)
 
+	k, err := hex.DecodeString(testKey)
+	require.NoError(t, err)
+	testCipher := crypto.NewCipher(k)
+
 	tests := []struct {
-		name string
+		name   string
+		cipher *crypto.Cipher
 	}{
-		{"add"},
+		{"add", nil},
+		{"add with cipher", testCipher},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			theCipher = tt.cipher
+
 			err := AddPSM(psm)
 			if err != nil {
 				t.Errorf("AddPSM() %s error %v", tt.name, err)
@@ -60,6 +72,8 @@ func Test_addPSM(t *testing.T) {
 			if diff := deep.Equal(psm, got); err != nil || diff != nil {
 				t.Errorf("GetPSM() diff %v, err %v", diff, err)
 			}
+
+			theCipher = nil
 		})
 	}
 }


### PR DESCRIPTION
Not sure if the encrypted version of psm storage is even used at all, but noticed this error when reusing the same code elsewhere.