### PR TITLE
Remove migration step from deployment container 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
       - name: upload coverage
         uses: codecov/codecov-action@v2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.txt
 
   e2e:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
+      - name: checkout
+        uses: actions/checkout@v2
       - name: download coverage file
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,5 @@
 name: test
 on:
-  workflow_run:
-    workflows: [release]
-    types: [completed]
   push:
 jobs:
   lint:
@@ -56,7 +53,6 @@ jobs:
       - name: upload coverage
         uses: codecov/codecov-action@v2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.txt
 
   e2e:

--- a/scripts/deploy/Dockerfile
+++ b/scripts/deploy/Dockerfile
@@ -60,7 +60,6 @@ ENV FCLI_AGENCY_REQUEST_TIMEOUT "3m"
 RUN echo '[[ ! -z "$STARTUP_FILE_STORAGE_S3" ]] && /s3-copy $STARTUP_FILE_STORAGE_S3 agent /' > /start.sh && \
     echo '[[ ! -z "$STARTUP_FILE_STORAGE_S3" ]] && /s3-copy $STARTUP_FILE_STORAGE_S3 grpc /grpc' >> /start.sh && \
     echo './import-wallet.sh' >> /start.sh && \
-    echo '/findy-agent agency migrate $FCLI_AGENCY_REGISTER_FILE $FCLI_AGENCY_REGISTER_FILE $FCLI_AGENCY_ENCLAVE_KEY' >> /start.sh && \
     echo '/findy-agent agency start' >> /start.sh && chmod a+x /start.sh
 
 ENTRYPOINT ["/bin/bash", "-c", "/start.sh"]


### PR DESCRIPTION
Remove migration step from deployment container, as updating from legacy agency version is not supported.