### PR TITLE
Use agent storage instead of indy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,10 +109,10 @@ testv:
 	$(GO) test -v -p 1 -failfast ./...
 
 test_cov_out:
-	$(GO) test -v -p 1 -failfast \
+	$(GO) test -p 1 -failfast \
+		-coverpkg=github.com/findy-network/findy-agent/... \
 		-coverprofile=coverage.txt  \
 		-covermode=atomic \
-		-coverpkg $(go list ./...) \
 		./...
 
 test_cov: test_cov_out

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,11 @@ testv:
 	$(GO) test -v -p 1 -failfast ./...
 
 test_cov_out:
-	$(GO) test -v -p 1 -failfast -coverprofile=coverage.txt ./...
+	$(GO) test -v -p 1 -failfast \
+		-coverprofile=coverage.txt  \
+		-covermode=atomic \
+		-coverpkg $(go list ./...) \
+		./...
 
 test_cov: test_cov_out
 	$(GO) tool cover -html=coverage.txt

--- a/agent/cloud/agent.go
+++ b/agent/cloud/agent.go
@@ -206,7 +206,7 @@ func (a *Agent) PwPipe(pwName string) (cp sec.Pipe, err error) {
 
 	cp.In = a.LoadDID(pw.MyDID)
 	outDID := a.LoadTheirDID(*pw)
-	outDID.StartEndp(a.Wallet())
+	outDID.StartEndp(a.ManagedWallet(), pwName)
 	cp.Out = outDID
 	return cp, nil
 }
@@ -323,6 +323,7 @@ func (a *Agent) ExportWallet(key string, exportPath string) string {
 func (a *Agent) loadPWMap() {
 	a.AssertWallet()
 
+	// TODO: PW CALL
 	r := <-indypw.List(a.Wallet())
 	if r.Err() != nil {
 		glog.Error("ERROR: could not load pw map:", r.Err())
@@ -337,7 +338,7 @@ func (a *Agent) loadPWMap() {
 	for _, d := range pwd {
 		pwData := ssi.FromIndyPairwise(d)
 		outDID := a.LoadTheirDID(pwData)
-		outDID.StartEndp(a.Wallet())
+		outDID.StartEndp(a.ManagedWallet(), pwData.Meta.Name)
 		p := sec.Pipe{
 			In:  a.LoadDID(d.MyDid),
 			Out: outDID,

--- a/agent/cloud/agent.go
+++ b/agent/cloud/agent.go
@@ -326,8 +326,7 @@ func (a *Agent) loadPWMap() {
 
 	a.AssertWallet()
 
-	connections, err := a.ManagedWallet().Storage().ConnectionStorage().ListConnections()
-	err2.Check(err)
+	connections := try.To1(a.ManagedWallet().Storage().ConnectionStorage().ListConnections())
 
 	a.pwLock.Lock()
 	defer a.pwLock.Unlock()

--- a/agent/comm/receiver.go
+++ b/agent/comm/receiver.go
@@ -7,6 +7,7 @@ import (
 	"github.com/findy-network/findy-agent/agent/managed"
 	"github.com/findy-network/findy-agent/agent/sec"
 	"github.com/findy-network/findy-agent/agent/ssi"
+	storage "github.com/findy-network/findy-agent/agent/storage/api"
 )
 
 type Receiver interface {
@@ -17,13 +18,13 @@ type Receiver interface {
 	RootDid() *ssi.DID
 	SendNYM(targetDid *ssi.DID, submitterDid, alias, role string) (err error)
 	LoadDID(did string) *ssi.DID
-	LoadTheirDID(pw ssi.Pairwise) *ssi.DID
+	LoadTheirDID(connection storage.Connection) *ssi.DID
 	WDID() string
 	PwPipe(pw string) (cp sec.Pipe, err error)
 	Wallet() int
 	ManagedWallet() managed.Wallet // TODO: access storage using wallet handle
 	Pool() int
-	FindPWByDID(my string) (pw *ssi.Pairwise, err error)
+	FindPWByDID(my string) (pw *storage.Connection, err error)
 	AttachSAImpl(implID string)
 	AddToPWMap(me, you *ssi.DID, name string) sec.Pipe
 	SaveTheirDID(did, vk string) (err error)

--- a/agent/pairwise/pairwise.go
+++ b/agent/pairwise/pairwise.go
@@ -30,7 +30,6 @@ type Callee struct {
 // MARK: Callee ---
 
 func (p *Callee) startStore() {
-	wallet := p.agent.Wallet()
 	p.Caller.Store(p.agent.ManagedWallet())
 	pwName := p.pairwiseName()
 
@@ -42,7 +41,7 @@ func (p *Callee) startStore() {
 		glog.Warning("Callee.startStore() - no DIDExchange request found")
 	}
 
-	p.Callee.SavePairwiseForDID(wallet, p.Caller, ssi.PairwiseMeta{
+	p.Callee.SavePairwiseForDID(p.agent.ManagedWallet(), p.Caller, ssi.PairwiseMeta{
 		Name:  pwName,
 		Route: route,
 	})

--- a/agent/pairwise/pairwise.go
+++ b/agent/pairwise/pairwise.go
@@ -7,7 +7,6 @@ import (
 	"github.com/findy-network/findy-agent/agent/pltype"
 	"github.com/findy-network/findy-agent/agent/ssi"
 	"github.com/findy-network/findy-agent/std/didexchange"
-	"github.com/findy-network/findy-wrapper-go/did"
 	"github.com/golang/glog"
 	"github.com/lainio/err2"
 	"github.com/lainio/err2/try"
@@ -70,13 +69,13 @@ func NewCalleePairwise(msgFactor didcomm.MsgFactor, agent ssi.Agent,
 func (p *Callee) CheckPreallocation(cnxAddr *endp.Addr) {
 	a := p.agent.(comm.Receiver)
 	calleeDID := a.LoadDID(cnxAddr.RcvrDID)
-	r := <-did.Meta(a.Wallet(), calleeDID.Did())
-	try.To(r.Err())
-	if r.Str1() == cnxAddr.EdgeToken {
+
+	store := a.ManagedWallet().Storage().ConnectionStorage()
+	if _, err := store.GetConnection(cnxAddr.EdgeToken); err == nil {
 		glog.V(1).Infoln("==== using preallocated pw DID ====", calleeDID.Did())
 		p.Callee = calleeDID
 	} else {
-		glog.V(1).Infoln("===== Cannot use pw DID, NO META =====")
+		glog.V(1).Infof("===== Cannot use pw DID, NO connection found with id %s =====", cnxAddr.EdgeToken)
 	}
 }
 

--- a/agent/pairwise/pairwise.go
+++ b/agent/pairwise/pairwise.go
@@ -6,7 +6,6 @@ import (
 	"github.com/findy-network/findy-agent/agent/endp"
 	"github.com/findy-network/findy-agent/agent/pltype"
 	"github.com/findy-network/findy-agent/agent/ssi"
-	storage "github.com/findy-network/findy-agent/agent/storage/api"
 	"github.com/findy-network/findy-agent/std/didexchange"
 	"github.com/golang/glog"
 	"github.com/lainio/err2"
@@ -67,19 +66,17 @@ func NewCalleePairwise(msgFactor didcomm.MsgFactor, agent ssi.Agent,
 	}
 }
 
-func (p *Callee) CheckPreallocation(cnxAddr *endp.Addr) *storage.Connection {
+func (p *Callee) CheckPreallocation(cnxAddr *endp.Addr) {
 	a := p.agent.(comm.Receiver)
 	calleeDID := a.LoadDID(cnxAddr.RcvrDID)
 
 	store := a.ManagedWallet().Storage().ConnectionStorage()
-	if conn, err := store.GetConnection(cnxAddr.EdgeToken); err == nil {
+	if _, err := store.GetConnection(cnxAddr.EdgeToken); err == nil {
 		glog.V(1).Infoln("==== using preallocated pw DID ====", calleeDID.Did())
 		p.Callee = calleeDID
-		return conn
 	}
 
 	glog.V(1).Infof("===== Cannot use pw DID, NO connection found with id %s =====", cnxAddr.EdgeToken)
-	return nil
 }
 
 func (p *Callee) ConnReqToRespWithSet(

--- a/agent/prot/processor.go
+++ b/agent/prot/processor.go
@@ -135,7 +135,7 @@ func ContinuePSM(shift Again) (err error) {
 	assert.D.True(pairwise != nil, "pairwise should not be nil")
 
 	outDID := wa.LoadTheirDID(*pairwise)
-	outDID.StartEndp(wa.Wallet())
+	outDID.StartEndp(wa.ManagedWallet(), pairwise.Meta.Name)
 	pipe := sec.Pipe{In: inDID, Out: outDID}
 
 	sendBack := shift.SendNext != pltype.Terminate
@@ -224,7 +224,7 @@ func ExecPSM(ts Transition) (err error) {
 
 		connID := pairwise.Meta.Name
 		outDID := ts.Receiver.LoadTheirDID(*pairwise)
-		outDID.StartEndp(ts.Receiver.Wallet())
+		outDID.StartEndp(ts.Receiver.ManagedWallet(), pairwise.Meta.Name)
 
 		ep = sec.Pipe{In: inDID, Out: outDID}
 		im := ts.Payload.MsgHdr()

--- a/agent/prot/processor.go
+++ b/agent/prot/processor.go
@@ -135,7 +135,7 @@ func ContinuePSM(shift Again) (err error) {
 	assert.D.True(pairwise != nil, "pairwise should not be nil")
 
 	outDID := wa.LoadTheirDID(*pairwise)
-	outDID.StartEndp(wa.ManagedWallet(), pairwise.Meta.Name)
+	outDID.StartEndp(wa.ManagedWallet(), pairwise.ID)
 	pipe := sec.Pipe{In: inDID, Out: outDID}
 
 	sendBack := shift.SendNext != pltype.Terminate
@@ -222,9 +222,9 @@ func ExecPSM(ts Transition) (err error) {
 		pairwise := try.To1(ts.Receiver.FindPWByDID(inDID.Did()))
 		assert.D.True(pairwise != nil, "pairwise should not be nil")
 
-		connID := pairwise.Meta.Name
+		connID := pairwise.ID
 		outDID := ts.Receiver.LoadTheirDID(*pairwise)
-		outDID.StartEndp(ts.Receiver.ManagedWallet(), pairwise.Meta.Name)
+		outDID.StartEndp(ts.Receiver.ManagedWallet(), pairwise.ID)
 
 		ep = sec.Pipe{In: inDID, Out: outDID}
 		im := ts.Payload.MsgHdr()

--- a/agent/psm/psm.go
+++ b/agent/psm/psm.go
@@ -221,7 +221,7 @@ func (p *PSM) PairwiseName() string {
 		pw := try.To1(r.FindPWByDID(p.ConnDID))
 
 		if pw != nil {
-			return pw.Meta.Name
+			return pw.ID
 		}
 	}
 	return ""

--- a/agent/ssi/agent.go
+++ b/agent/ssi/agent.go
@@ -184,7 +184,7 @@ func (a *DIDAgent) CreateDID(seed string) (agentDid *DID) {
 		// Catch did result here and store it also to the agent storage
 		didRes := <-did.CreateAndStore(a.Wallet(), did.Did{Seed: seed})
 		glog.V(5).Infof("agent storage Add DID %s", didRes.Data.Str1)
-		try.To(a.WalletH.Storage().DIDStorage().AddDID(api.DID{
+		try.To(a.WalletH.Storage().DIDStorage().SaveDID(api.DID{
 			ID:         didRes.Data.Str1,
 			DID:        didRes.Data.Str1,
 			IndyVerKey: didRes.Data.Str2,

--- a/agent/ssi/agent.go
+++ b/agent/ssi/agent.go
@@ -284,8 +284,7 @@ func (a *DIDAgent) FindPWByDID(my string) (pw *storage.Connection, err error) {
 
 	a.AssertWallet()
 
-	connections, err := a.ManagedWallet().Storage().ConnectionStorage().ListConnections()
-	err2.Check(err)
+	connections := try.To1(a.ManagedWallet().Storage().ConnectionStorage().ListConnections())
 
 	for _, item := range connections {
 		if item.MyDID == my {

--- a/agent/ssi/agent.go
+++ b/agent/ssi/agent.go
@@ -296,6 +296,7 @@ func FromIndyPairwise(pw pairwise.Data) Pairwise {
 
 func (a *DIDAgent) FindPWByName(name string) (pw *Pairwise, err error) {
 	a.AssertWallet()
+	// TODO: PW CALL
 	r := <-pairwise.List(a.Wallet())
 	if r.Err() != nil {
 		return nil, fmt.Errorf("agent pairwise: %s", r.Err())
@@ -314,6 +315,8 @@ func (a *DIDAgent) FindPWByName(name string) (pw *Pairwise, err error) {
 // FindPWByDID finds pairwise by my DID. This is a ReceiverEndp interface method.
 func (a *DIDAgent) FindPWByDID(my string) (pw *Pairwise, err error) {
 	a.AssertWallet()
+
+	// TODO: PW CALL
 	r := <-pairwise.List(a.Wallet())
 	if r.Err() != nil {
 		return nil, fmt.Errorf("agent pairwise: %s", r.Err())

--- a/agent/ssi/did.go
+++ b/agent/ssi/did.go
@@ -127,12 +127,13 @@ func (d *DID) Store(mgdWallet managed.Wallet) {
 	idJSON := did.Did{Did: ds, VerKey: vk}
 	json := dto.ToJSON(idJSON)
 
+	// TODO: DID CALL
 	f := new(Future)
 	f.SetChan(did.StoreTheir(mgdWallet.Handle(), json))
 
 	// Store did it also to the agent storage
 	glog.V(5).Infof("agent storage Store DID %s", ds)
-	try.To(mgdWallet.Storage().DIDStorage().AddDID(storage.DID{
+	try.To(mgdWallet.Storage().DIDStorage().SaveDID(storage.DID{
 		ID:         ds,
 		DID:        ds,
 		IndyVerKey: vk,
@@ -181,6 +182,7 @@ func (d *DID) SavePairwiseForDID(wallet int, theirDID *DID, pw PairwiseMeta) {
 		f := &Future{}
 		meta := base64.StdEncoding.EncodeToString(dto.ToJSONBytes(pw))
 
+		// TODO: PW CALL
 		f.SetChan(pairwise.Create(wallet, theirDID.Did(), d.Did(), meta))
 		theirDID.pw = f
 	} else {
@@ -195,6 +197,7 @@ func (d *DID) hasKeyData() bool {
 
 func (d *DID) StartEndp(wallet int) {
 	f := &Future{}
+	// TODO: DID CALL
 	f.SetChan(did.Endpoint(wallet, Pool(), d.Did()))
 	d.Lock()
 	d.endp = f

--- a/agent/ssi/did.go
+++ b/agent/ssi/did.go
@@ -182,6 +182,7 @@ func (d *DID) SavePairwiseForDID(mgdWallet managed.Wallet, theirDID *DID, pw Pai
 		err := store.SaveConnection(*connection)
 		errStr := ""
 		if err != nil {
+			ok = false
 			errStr = err.Error()
 		}
 

--- a/agent/ssi/did.go
+++ b/agent/ssi/did.go
@@ -127,7 +127,6 @@ func (d *DID) Store(mgdWallet managed.Wallet) {
 	idJSON := did.Did{Did: ds, VerKey: vk}
 	json := dto.ToJSON(idJSON)
 
-	// TODO: DID CALL
 	f := new(Future)
 	f.SetChan(did.StoreTheir(mgdWallet.Handle(), json))
 
@@ -195,10 +194,22 @@ func (d *DID) hasKeyData() bool {
 	return vk != ""
 }
 
-func (d *DID) StartEndp(wallet int) {
-	f := &Future{}
-	// TODO: DID CALL
-	f.SetChan(did.Endpoint(wallet, Pool(), d.Did()))
+func (d *DID) StartEndp(wallet managed.Wallet, connectionID string) {
+	store := wallet.Storage().ConnectionStorage()
+	connection, err := store.GetConnection(connectionID)
+	endpoint := ""
+	errStr := ""
+	if err == nil {
+		endpoint = connection.TheirEndpoint
+	} else {
+		errStr = err.Error()
+	}
+
+	f := &Future{V: indyDto.Result{
+		Data: indyDto.Data{Str1: endpoint},
+		Er:   indyDto.Err{Error: errStr},
+	}, On: Consumed}
+
 	d.Lock()
 	d.endp = f
 	d.Unlock()

--- a/agent/ssi/wallet.go
+++ b/agent/ssi/wallet.go
@@ -67,12 +67,6 @@ func walletPath() string {
 	return filepath.Join(home, workerSubPath)
 }
 
-func (w *Wallet) StartCreation() (f *Future) {
-	f = new(Future)
-	f.SetChan(wallet.Create(w.Config, w.Credentials))
-	return f
-}
-
 func (w *Wallet) Create() (exist bool) {
 	r := <-wallet.Create(w.Config, w.Credentials)
 	if r.Err() != nil {

--- a/agent/storage/api/storage.go
+++ b/agent/storage/api/storage.go
@@ -22,7 +22,7 @@ type AgentStorage interface {
 }
 
 type DIDStorage interface {
-	AddDID(did DID) error
+	SaveDID(did DID) error
 	GetDID(id string) (*DID, error)
 }
 
@@ -35,7 +35,7 @@ type Connection struct {
 }
 
 type ConnectionStorage interface {
-	AddConnection(conn Connection) error
+	SaveConnection(conn Connection) error
 	GetConnection(id string) (*Connection, error)
 	ListConnections() ([]Connection, error)
 }

--- a/agent/storage/api/storage.go
+++ b/agent/storage/api/storage.go
@@ -28,7 +28,7 @@ type DIDStorage interface {
 
 type Connection struct {
 	ID            string
-	OurDID        string
+	MyDID         string
 	TheirDID      string
 	TheirEndpoint string
 	TheirRoute    []string

--- a/agent/storage/doc.go
+++ b/agent/storage/doc.go
@@ -1,0 +1,1 @@
+package storage

--- a/agent/storage/mgddb/storage.go
+++ b/agent/storage/mgddb/storage.go
@@ -98,7 +98,7 @@ func (s *Storage) CredentialStorage() api.CredentialStorage {
 }
 
 // DIDStorage
-func (s *Storage) AddDID(did api.DID) (err error) {
+func (s *Storage) SaveDID(did api.DID) (err error) {
 	return s.didStore.Put(did.ID, dto.ToGOB(did))
 }
 
@@ -113,7 +113,7 @@ func (s *Storage) GetDID(id string) (did *api.DID, err error) {
 }
 
 // ConnectionStorage
-func (s *Storage) AddConnection(conn api.Connection) error {
+func (s *Storage) SaveConnection(conn api.Connection) error {
 	return s.connStore.Put(conn.ID, dto.ToGOB(conn))
 }
 

--- a/agent/storage/storage_test.go
+++ b/agent/storage/storage_test.go
@@ -105,7 +105,7 @@ func TestDIDStore(t *testing.T) {
 				ID:  "did:test:123",
 				DID: "did:test:123",
 			}
-			err := store.AddDID(testDID)
+			err := store.SaveDID(testDID)
 			require.NoError(t, err)
 
 			gotDID, err := store.GetDID(testDID.ID)
@@ -127,7 +127,7 @@ func TestConnectionStore(t *testing.T) {
 				TheirEndpoint: "https://example.com",
 				TheirRoute:    []string{"routeKey"},
 			}
-			err := store.AddConnection(testConn)
+			err := store.SaveConnection(testConn)
 			require.NoError(t, err)
 
 			gotConn, err := store.GetConnection(testConn.ID)
@@ -136,7 +136,7 @@ func TestConnectionStore(t *testing.T) {
 
 			testConn2 := testConn
 			testConn2.ID = "456-uid"
-			err = store.AddConnection(testConn2)
+			err = store.SaveConnection(testConn2)
 			require.NoError(t, err)
 
 			conns, err := store.ListConnections()

--- a/agent/storage/storage_test.go
+++ b/agent/storage/storage_test.go
@@ -122,7 +122,7 @@ func TestConnectionStore(t *testing.T) {
 			store := testCase.storage.ConnectionStorage()
 			testConn := api.Connection{
 				ID:            "123-uid",
-				OurDID:        "did:test:123",
+				MyDID:         "did:test:123",
 				TheirDID:      "did:test:456",
 				TheirEndpoint: "https://example.com",
 				TheirRoute:    []string{"routeKey"},

--- a/grpc/server/agent.go
+++ b/grpc/server/agent.go
@@ -271,7 +271,7 @@ func preallocatePWDID(ctx context.Context, id string) (ep *endp.Addr, err error)
 	store := receiver.ManagedWallet().Storage().ConnectionStorage()
 	try.To(store.SaveConnection(storage.Connection{
 		ID:     id,
-		OurDID: ourPairwiseDID.Did(),
+		MyDID: ourPairwiseDID.Did(),
 	}))
 
 	ep.RcvrDID = ourPairwiseDID.Did()

--- a/grpc/server/agent.go
+++ b/grpc/server/agent.go
@@ -270,7 +270,7 @@ func preallocatePWDID(ctx context.Context, id string) (ep *endp.Addr, err error)
 	// mark the preallocated pairwise DID with connection ID that we find it
 	store := receiver.ManagedWallet().Storage().ConnectionStorage()
 	try.To(store.SaveConnection(storage.Connection{
-		ID:     id,
+		ID:    id,
 		MyDID: ourPairwiseDID.Did(),
 	}))
 

--- a/grpc/server/agent.go
+++ b/grpc/server/agent.go
@@ -10,6 +10,7 @@ import (
 	"github.com/findy-network/findy-agent/agent/prot"
 	"github.com/findy-network/findy-agent/agent/psm"
 	"github.com/findy-network/findy-agent/agent/ssi"
+	storage "github.com/findy-network/findy-agent/agent/storage/api"
 	"github.com/findy-network/findy-agent/agent/utils"
 	"github.com/findy-network/findy-common-go/dto"
 	pb "github.com/findy-network/findy-common-go/grpc/agency/v1"
@@ -17,7 +18,6 @@ import (
 	didexchange "github.com/findy-network/findy-common-go/std/didexchange/invitation"
 	"github.com/findy-network/findy-wrapper-go"
 	"github.com/findy-network/findy-wrapper-go/anoncreds"
-	"github.com/findy-network/findy-wrapper-go/did"
 	"github.com/findy-network/findy-wrapper-go/ledger"
 	"github.com/golang/glog"
 	"github.com/lainio/err2"
@@ -268,8 +268,11 @@ func preallocatePWDID(ctx context.Context, id string) (ep *endp.Addr, err error)
 	ourPairwiseDID := ssiWA.CreateDID("")
 
 	// mark the preallocated pairwise DID with connection ID that we find it
-	r := <-did.SetMeta(wa.Wallet(), ourPairwiseDID.Did(), id)
-	try.To(r.Err())
+	store := receiver.ManagedWallet().Storage().ConnectionStorage()
+	try.To(store.SaveConnection(storage.Connection{
+		ID:     id,
+		OurDID: ourPairwiseDID.Did(),
+	}))
 
 	ep.RcvrDID = ourPairwiseDID.Did()
 	ep.EdgeToken = id

--- a/protocol/basicmessage/basic_message_protocol.go
+++ b/protocol/basicmessage/basic_message_protocol.go
@@ -104,7 +104,7 @@ func handleBasicMessage(packet comm.Packet) (err error) {
 
 		if glog.V(3) {
 			glog.Info("-- Thread id: ", im.Thread().ID)
-			glog.Info("Basic msg from:", pw.Meta.Name)
+			glog.Info("Basic msg from:", pw.ID)
 			glog.Info("Sent time:", bm.SentTime)
 			glog.Info("Content: ", bm.Content)
 		}
@@ -116,7 +116,7 @@ func handleBasicMessage(packet comm.Packet) (err error) {
 
 		rep := &basicMessageRep{
 			StateKey:      key,
-			PwName:        pw.Meta.Name,
+			PwName:        pw.ID,
 			Message:       bm.Content,
 			SendTimestamp: bm.SentTime.Time.UnixNano(),
 			Timestamp:     time.Now().UnixNano(),

--- a/protocol/connection/connection_protocol.go
+++ b/protocol/connection/connection_protocol.go
@@ -327,7 +327,7 @@ func handleConnectionResponse(packet comm.Packet) (err error) {
 
 	pwName := pwr.Name
 	route := didexchange.RouteForConnection(response.Connection)
-	caller.SavePairwiseForDID(a.Wallet(), callee, ssi.PairwiseMeta{
+	caller.SavePairwiseForDID(a.ManagedWallet(), callee, ssi.PairwiseMeta{
 		Name:  pwName,
 		Route: route,
 	})

--- a/protocol/connection/connection_protocol.go
+++ b/protocol/connection/connection_protocol.go
@@ -252,6 +252,7 @@ func handleConnectionRequest(packet comm.Packet) (err error) {
 	try.To(psm.AddRep(pwr))
 
 	// SAVE ENDPOINT to wallet
+	// TODO: DID CALL
 	r := <-did.SetEndpoint(a.Wallet(), caller.Did(), callerAddress, callerEndp.VerKey)
 
 	try.To(r.Err())
@@ -335,6 +336,7 @@ func handleConnectionResponse(packet comm.Packet) (err error) {
 
 	// SAVE ENDPOINT to wallet
 	calleeEndp := endp.NewAddrFromPublic(im.Endpoint())
+	// TODO: DID CALL
 	r := <-did.SetEndpoint(a.Wallet(), callee.Did(), calleeEndp.Address(), calleeEndp.VerKey)
 	try.To(r.Err())
 


### PR DESCRIPTION
* replace use of indy's did endpoint and meta APIs with new connection storage
* replace use of indy's pairwise API with new connection storage

Approach has been moreless stupid: just replace the current functionality with minimal changes. We should probably consider at some point that do we need separate buckets for DIDs and connections or could we just cope only with connections.