### PR TITLE
Add JS agent to interop tests.

### DIFF
--- a/.github/workflows/iop.yml
+++ b/.github/workflows/iop.yml
@@ -12,16 +12,28 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: test findy as Bob
+      - name: test findy as Bob with ACAPy
         run: |
           cd ./scripts/aath
           make run-check AGENT_DEFAULT=acapy AGENT_BOB=findy
         env:
           NO_TTY: "1"
-      - name: test findy as default agent
+      - name: test findy as default agent with ACAPy
         run: |
           cd ./scripts/aath
           make test-check AGENT_DEFAULT=findy AGENT_BOB=acapy
+        env:
+          NO_TTY: "1"
+      - name: test findy as Bob with javascript
+        run: |
+          cd ./scripts/aath
+          make test-check AGENT_DEFAULT=javascript AGENT_BOB=findy
+        env:
+          NO_TTY: "1"
+      - name: test findy as default with javascript
+        run: |
+          cd ./scripts/aath
+          make test-check AGENT_DEFAULT=findy AGENT_BOB=javascript
         env:
           NO_TTY: "1"
       - name: store agency logs

--- a/scripts/aath/Makefile
+++ b/scripts/aath/Makefile
@@ -2,8 +2,8 @@ AGENT_DEFAULT?=acapy
 AGENT_BOB?=findy
 INCLUDE_TAGS?='@AcceptanceTest'
 
-run: clone agency-up tag test
-run-check: clone agency-up tag test-check
+run: clone agency-up services-up tag test
+run-check: clone agency-up services-up tag test-check
 
 record-logs:
 	mkdir -p .logs
@@ -51,11 +51,19 @@ agency-up:
 	cd ../dev/docker && \
 		make up-d
 
+services-up:
+	cd .docker/findy-agent-backchannel/env && \
+		make clone && \
+		make tails-up && \
+		make resolver-up
+
 tag:
 	docker pull ghcr.io/findy-network/findy-agent-backchannel:findy-bc-latest
 	docker tag ghcr.io/findy-network/findy-agent-backchannel:findy-bc-latest findy-agent-backchannel:latest
 	docker pull ghcr.io/findy-network/findy-agent-backchannel:acapy-bc-latest
 	docker tag ghcr.io/findy-network/findy-agent-backchannel:acapy-bc-latest acapy-agent-backchannel:latest
+	docker pull ghcr.io/findy-network/findy-agent-backchannel:javascript-bc-latest
+	docker tag ghcr.io/findy-network/findy-agent-backchannel:javascript-bc-latest javascript-agent-backchannel:latest
 	docker pull ghcr.io/findy-network/findy-agent-backchannel:aath-latest
 	docker tag ghcr.io/findy-network/findy-agent-backchannel:aath-latest aries-test-harness:latest
 


### PR DESCRIPTION
Apparently there are happening random failures with JS agent and findy agent on AATH tests. Let's add the tests with JS agent to interop test set if we could catch the error and see the logs.