### PR TITLE
Add verification for connection status

### DIFF
--- a/grpc/grpc_test.go
+++ b/grpc/grpc_test.go
@@ -1139,7 +1139,7 @@ func TestListenPWStatus(t *testing.T) {
 
 	ch := try.To1(conn1.Listen(ctx, &agency2.ClientID{ID: utils.UUID()}))
 
-	var notification agency2.Question
+	var notification *agency2.Question
 	go func() {
 		defer err2.Catch(func(err error) {
 			if !errors.Is(err, context.Canceled) {
@@ -1148,7 +1148,7 @@ func TestListenPWStatus(t *testing.T) {
 		})
 		for status := range ch {
 			if status.Status.Notification.TypeID == agency2.Notification_STATUS_UPDATE {
-				notification = *status
+				notification = status
 				wg.Done()
 			}
 		}

--- a/grpc/grpc_test.go
+++ b/grpc/grpc_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/findy-network/findy-agent/agent/agency"
 	"github.com/findy-network/findy-agent/agent/cloud"
 	"github.com/findy-network/findy-agent/agent/didcomm"
+	"github.com/findy-network/findy-agent/agent/endp"
 	"github.com/findy-network/findy-agent/agent/handshake"
 	"github.com/findy-network/findy-agent/agent/pool"
 	"github.com/findy-network/findy-agent/agent/psm"
@@ -1475,16 +1476,27 @@ func handleStatusBMEcho(
 	status *agency2.AgentStatus,
 	_ bool,
 ) handleAction {
+	assert.True(t, endp.IsUUID(status.Notification.ConnectionID))
+
+	ctx := context.Background()
+	didComm := agency2.NewProtocolServiceClient(conn)
+	statusResult := try.To1(didComm.Status(ctx, &agency2.ProtocolID{
+		TypeID:           status.Notification.ProtocolType,
+		Role:             agency2.Protocol_ADDRESSEE,
+		ID:               status.Notification.ProtocolID,
+		NotificationTime: status.Notification.Timestamp,
+	}))
+
 	switch status.Notification.ProtocolType {
+	case agency2.Protocol_DIDEXCHANGE:
+		res := statusResult.GetDIDExchange()
+		assert.NotEmpty(t, res.TheirDID)
+		assert.NotEmpty(t, res.MyDID)
+		assert.NotEmpty(t, res.TheirLabel)
+		assert.NotEmpty(t, res.TheirEndpoint)
+		assert.Equal(t, status.Notification.ConnectionID, res.ID)
+		return handleNotOurs
 	case agency2.Protocol_BASIC_MESSAGE:
-		ctx := context.Background()
-		didComm := agency2.NewProtocolServiceClient(conn)
-		statusResult := try.To1(didComm.Status(ctx, &agency2.ProtocolID{
-			TypeID:           status.Notification.ProtocolType,
-			Role:             agency2.Protocol_ADDRESSEE,
-			ID:               status.Notification.ProtocolID,
-			NotificationTime: status.Notification.Timestamp,
-		}))
 		if statusResult.GetBasicMessage().SentByMe {
 			glog.V(0).Infoln("---------- ours, no reply")
 			return handleOK


### PR DESCRIPTION
Added test that will check notification connection ID is in UUID-format and verify that connection status is not empty.

This test should fail until branch `did-doc-afgo` is merged.

~For some reason the tests fail at local environment but not in CI. Apparently there are some timing issues why the test is skipped in CI 🤔~
Added a dedicated test for checking connection notifications.