### PR TITLE
Add test for two onboarded agents with same public DID.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ scripts/dev/docker/get-docker-host.sh
 
 codecov
 coverage.txt
+gen_txn_file

--- a/agent/cloud/agent.go
+++ b/agent/cloud/agent.go
@@ -246,7 +246,7 @@ func (a *Agent) workerAgent(waDID, suffix string) (wa *Agent) {
 
 		if !walletInitializedBefore {
 			glog.V(2).Info("Creating a master secret into worker's wallet")
-			masterSec, err := enclave.NewWalletMasterSecret(ca.RootDid().Did())
+			masterSec, err := enclave.NewWalletMasterSecret(ca.myDID.Did())
 			if err != nil {
 				glog.Error(err)
 				panic(err)
@@ -268,7 +268,7 @@ func (a *Agent) ID() string {
 }
 
 func (a *Agent) MasterSecret() (string, error) {
-	return enclave.WalletMasterSecretByDID(a.RootDid().Did())
+	return enclave.WalletMasterSecretByDID(a.myDID.Did())
 }
 
 // WDID returns DID string of the WA and CALLED from CA.

--- a/scripts/unit-tests/Dockerfile
+++ b/scripts/unit-tests/Dockerfile
@@ -1,0 +1,32 @@
+FROM ghcr.io/findy-network/findy-base:indy-1.16.ubuntu-18.04 AS indy-base
+
+FROM golang:1.18-buster AS agent-builder
+
+ENV INDY_LIB_VERSION="1.16.0"
+ENV FCLI_LOGGING "-logtostderr -v=9 -vmodule=cmdHandles=10,agency*=15,agent*=15"
+ENV FCLI_POOL_NAME "von"
+ENV FCLI_AGENCY_POOL_NAME "FINDY_LEDGER,von"
+ENV CI "true"
+# TODO: linux
+ENV VON_WEB_SERVER_URL "http://host.docker.internal:9000"
+
+# install indy deps and files from base
+RUN apt-get update && apt-get install -y libsodium23 libssl1.1 libzmq5
+COPY --from=indy-base /usr/include/indy /usr/include/indy
+COPY --from=indy-base /usr/lib/libindy.a /usr/lib/libindy.a
+COPY --from=indy-base /usr/lib/libindy.so /usr/lib/libindy.so
+
+WORKDIR /work
+
+COPY go.* ./
+RUN go mod download
+
+RUN echo '#!/bin/sh' > /test.sh && \
+    echo "cd /work " >> /test.sh && \
+    echo "curl http://host.docker.internal:9000/genesis > gen_txn_file" >> /test.sh && \
+    echo "make test" >> /test.sh && \
+    chmod a+x /test.sh
+
+ENTRYPOINT ["/test.sh"]
+
+

--- a/scripts/unit-tests/Makefile
+++ b/scripts/unit-tests/Makefile
@@ -1,0 +1,23 @@
+VON_NETWORK_VERSION:="22973513c99cc9a286a6f181ca5c5f354a4eb2ee"
+
+test: von-up build test-only
+
+test-only:
+	@echo "Start test in docker container"
+	docker run -it --rm -v $(PWD)/../../:/work findy-agent-unit-tests 
+
+build:
+	cd ../.. && \
+		docker build -t findy-agent-unit-tests -f ./scripts/unit-tests/Dockerfile .
+
+clone:
+	mkdir -p .docker
+	-git clone https://github.com/bcgov/von-network .docker/von-network
+	cd .docker/von-network && git reset --hard $(VON_NETWORK_VERSION)
+
+von-up: clone
+	cd .docker/von-network && ./manage build && ./manage up
+	../dev/docker/wait-for-ledger.sh
+
+down:
+	cd .docker/von-network && ./manage down


### PR DESCRIPTION
While doing other testing, I encountered this issue: when two agents have been onboarded with same public DID seed, generating invitations fail with error `master secret already exists`. Let's discuss if we should support this scenario and if not, how to fail the onboarding for agents trying to use a previously reserved seed.