### PR TITLE
Do not require protocol type for status getter query.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ scripts/dev/docker/get-docker-host.sh
 
 codecov
 coverage.txt
+gen_txn_file

--- a/grpc/server/agency.go
+++ b/grpc/server/agency.go
@@ -10,13 +10,11 @@ import (
 	"github.com/findy-network/findy-agent/agent/bus"
 	"github.com/findy-network/findy-agent/agent/comm"
 	"github.com/findy-network/findy-agent/agent/handshake"
-	"github.com/findy-network/findy-agent/agent/pltype"
 	"github.com/findy-network/findy-agent/agent/prot"
 	"github.com/findy-network/findy-agent/agent/psm"
 	"github.com/findy-network/findy-agent/agent/utils"
 	"github.com/findy-network/findy-agent/enclave"
 	"github.com/findy-network/findy-agent/method"
-	pb "github.com/findy-network/findy-common-go/grpc/agency/v1"
 	ops "github.com/findy-network/findy-common-go/grpc/ops/v1"
 	"github.com/findy-network/findy-common-go/jwt"
 	"github.com/golang/glog"
@@ -165,18 +163,13 @@ func handleNotify(hook *ops.DataHook, server ops.AgencyService_PSMHookServer, no
 	})
 
 	glog.V(1).Infoln("notification", notify.ID, "arrived")
-	pid := &pb.ProtocolID{
-		TypeID: pltype.ProtocolTypeForFamily(notify.ProtocolFamily),
-		Role:   notify.Role,
-		ID:     notify.ProtocolID,
-	}
 
 	psmKey := psm.StateKey{
 		DID:   notify.AgentDID,
 		Nonce: notify.ProtocolID,
 	}
 
-	status, connID := tryProtocolStatus(pid, psmKey)
+	status, connID := tryProtocolStatus(psmKey)
 	glog.Infoln("connID:", connID)
 	agentStatus := ops.AgencyStatus{
 		DID:            tryCaDID(psmKey),

--- a/grpc/server/agent.go
+++ b/grpc/server/agent.go
@@ -470,7 +470,7 @@ func processQuestion(ctx context.Context, notify bus.AgentNotify) (as *pb.Questi
 	caDID, receiver := try.To2(ca(ctx))
 	key := psm.NewStateKey(receiver.WorkerEA(), id.ID)
 	glog.V(1).Infoln(caDID, "-agent protocol status:", pb.Protocol_Type_name[int32(id.TypeID)], protocolName[id.TypeID])
-	ps, _ := tryProtocolStatus(id, key)
+	ps, _ := tryProtocolStatus(key)
 
 	switch notificationProtocolType {
 	case pb.Protocol_ISSUE_CREDENTIAL:


### PR DESCRIPTION
I usually always forget to append the protocol type to the status query request and wonder why it is not working. Maybe we could support the status query without explicitly setting the protocol type as it is available in the psm db?