### PR TITLE
Support proof request names param

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/findy-network/findy-common-go v0.1.42
-	github.com/findy-network/findy-wrapper-go v0.30.17-0.20220902051342-2df8f30e03a7
+	github.com/findy-network/findy-wrapper-go v0.30.17
 	github.com/go-co-op/gocron v1.16.1
 	github.com/go-test/deep v1.0.8
 	github.com/golang/glog v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/findy-network/findy-common-go v0.1.42
-	github.com/findy-network/findy-wrapper-go v0.30.15
+	github.com/findy-network/findy-wrapper-go v0.30.17-0.20220902051342-2df8f30e03a7
 	github.com/go-co-op/gocron v1.16.1
 	github.com/go-test/deep v1.0.8
 	github.com/golang/glog v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/findy-network/findy-common-go v0.1.42 h1:igEk7bfmkmcWCIMzQNWQcpS63D7TOroxoUNhn/tcsVU=
 github.com/findy-network/findy-common-go v0.1.42/go.mod h1:nuHxuvSIdXj5nbOJwutsOvI9Px42pZAN5bZoexD89OM=
-github.com/findy-network/findy-wrapper-go v0.30.17-0.20220902051342-2df8f30e03a7 h1:+wlB3iBqc9QybU1dliZP8czP1kBrOyNNjvP1di4jvWc=
-github.com/findy-network/findy-wrapper-go v0.30.17-0.20220902051342-2df8f30e03a7/go.mod h1:6oXzSVeQ3yOxnv4CtsVqggdSIMKR7LllwF98xgfbYEc=
+github.com/findy-network/findy-wrapper-go v0.30.17 h1:yXwXtq2w+JB5lmP7TP+3zkO33h0G3UZiEHqBeKJvq1c=
+github.com/findy-network/findy-wrapper-go v0.30.17/go.mod h1:6oXzSVeQ3yOxnv4CtsVqggdSIMKR7LllwF98xgfbYEc=
 github.com/form3tech-oss/jwt-go v3.2.5+incompatible h1:/l4kBbb4/vGSsdtB5nUe8L7B9mImVMaBPw9L/0TBHU8=
 github.com/form3tech-oss/jwt-go v3.2.5+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/findy-network/findy-common-go v0.1.42 h1:igEk7bfmkmcWCIMzQNWQcpS63D7TOroxoUNhn/tcsVU=
 github.com/findy-network/findy-common-go v0.1.42/go.mod h1:nuHxuvSIdXj5nbOJwutsOvI9Px42pZAN5bZoexD89OM=
-github.com/findy-network/findy-wrapper-go v0.30.15 h1:STBtkEIkCWMHbR17vHiovaMbZm+JrA5c9+1nLTyRvFo=
-github.com/findy-network/findy-wrapper-go v0.30.15/go.mod h1:GKvenFx3DbpKxmaDIhMYzRjri/jG7WI73m3508bn7Hs=
+github.com/findy-network/findy-wrapper-go v0.30.17-0.20220902051342-2df8f30e03a7 h1:+wlB3iBqc9QybU1dliZP8czP1kBrOyNNjvP1di4jvWc=
+github.com/findy-network/findy-wrapper-go v0.30.17-0.20220902051342-2df8f30e03a7/go.mod h1:6oXzSVeQ3yOxnv4CtsVqggdSIMKR7LllwF98xgfbYEc=
 github.com/form3tech-oss/jwt-go v3.2.5+incompatible h1:/l4kBbb4/vGSsdtB5nUe8L7B9mImVMaBPw9L/0TBHU8=
 github.com/form3tech-oss/jwt-go v3.2.5+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=

--- a/protocol/presentproof/preview/store.go
+++ b/protocol/presentproof/preview/store.go
@@ -2,6 +2,8 @@
 package preview
 
 import (
+	"fmt"
+
 	"github.com/findy-network/findy-agent/agent/didcomm"
 	"github.com/findy-network/findy-agent/protocol/presentproof/data"
 	"github.com/findy-network/findy-common-go/dto"
@@ -17,9 +19,22 @@ func StoreProofData(requestData []byte, rep *data.PresentProofRep) {
 		if len(attr.Restrictions) > 0 {
 			credDefID = attr.Restrictions[0].CredDefID
 		}
-		rep.Attributes = append(
-			rep.Attributes,
-			didcomm.ProofAttribute{ID: id, Name: attr.Name, CredDefID: credDefID},
-		)
+		if attr.Name != "" {
+			rep.Attributes = append(
+				rep.Attributes,
+				didcomm.ProofAttribute{ID: id, Name: attr.Name, CredDefID: credDefID},
+			)
+		} else {
+			for index, name := range attr.Names {
+				rep.Attributes = append(
+					rep.Attributes,
+					didcomm.ProofAttribute{
+						ID:        fmt.Sprintf("%s_%d", id, index),
+						Name:      name,
+						CredDefID: credDefID,
+					},
+				)
+			}
+		}
 	}
 }


### PR DESCRIPTION
It seems that indy proof request can contain also "names"-field that contains several attribute names in one array:

```
{
    "name": "University of Law Request",
    "version": "University of Law Request",
    "nonce": "1181689245109897081892374",
    "requested_attributes": {
        "Animo ID Card": {
            "restrictions": [
                {
                    "cred_def_id": "WVqppUv9X3WyWGrbns5Uia:3:CL:89471:Animo ID Card"
                }
            ],
            "names": [
                "Name",
                "Date of birth"
            ]
        }
    },
    "requested_predicates": {}
}
```

Adding conversion from this array to rep attributes so that proof attributes are reported correctly to core clients via status API.