### PR TITLE
Use CA DID as persistent storage keys

### DIFF
--- a/agent/cloud/agent.go
+++ b/agent/cloud/agent.go
@@ -211,7 +211,7 @@ func (a *Agent) PwPipe(connID string) (cp sec.Pipe, err error) {
 func (a *Agent) workerAgent(waDID, suffix string) (wa *Agent) {
 	ca := a // to help us to read the code, receiver is CA
 	return ca.worker.testAndSet(func() *Agent {
-		glog.V(2).Infoln("starting worker agent creation process")
+		glog.V(2).Infof("starting worker agent (%s) creation process", waDID)
 		assert.P.True(waDID == ca.WDID(), "Agent URL doesn't match with Transport")
 
 		cfg := ca.WalletH.Config().(*ssi.Wallet)
@@ -245,7 +245,7 @@ func (a *Agent) workerAgent(waDID, suffix string) (wa *Agent) {
 		comm.ActiveRcvrs.Add(waDID, wca)
 
 		if !walletInitializedBefore {
-			glog.V(2).Info("Creating a master secret into worker's wallet")
+			glog.V(2).Infof("Creating a master secret into worker's wallet (%s)", ca.myDID.Did())
 			masterSec, err := enclave.NewWalletMasterSecret(ca.myDID.Did())
 			if err != nil {
 				glog.Error(err)

--- a/agent/cloud/agent.go
+++ b/agent/cloud/agent.go
@@ -218,8 +218,7 @@ func (a *Agent) workerAgent(waDID, suffix string) (wa *Agent) {
 		aWallet := cfg.WorkerWalletBy(suffix)
 
 		// getting wallet credentials
-		// CA and EA wallets have same key, they have same root DID
-		key, err := enclave.WalletKeyByDID(ca.RootDid().KID())
+		key, err := enclave.WalletKeyByDID(ca.myDID.Did())
 		if err != nil {
 			glog.Error("cannot get wallet key:", err)
 			panic(err)

--- a/agent/handshake/agency.go
+++ b/agent/handshake/agency.go
@@ -108,6 +108,7 @@ func AnchorAgent(agentName, seed string) (agent *cloud.Agent, err error) {
 	// from a pairwise only CA wallet in continuous backup process.
 	accessmgr.Send(agent.WalletH)
 
+	glog.V(2).Infof("--- Saving enclave key for %s", anchorDid.KID())
 	try.To(enclave.SetKeysDID(key, anchorDid.KID()))
 
 	return agent, nil
@@ -156,6 +157,8 @@ func LoadRegistered(filename string) (err error) {
 			})
 
 			if !alreadyRegistered[name] {
+				glog.V(2).Infof("Loading enclave key for root: %s, ca: %s", rootDid, caDID)
+
 				key := try.To1(enclave.WalletKeyByEmail(email))
 				keyByDid := try.To1(enclave.WalletKeyByDID(rootDid))
 

--- a/agent/handshake/agency.go
+++ b/agent/handshake/agency.go
@@ -16,6 +16,7 @@ import (
 	"github.com/findy-network/findy-agent/agent/cloud"
 	"github.com/findy-network/findy-agent/agent/ssi"
 	"github.com/findy-network/findy-agent/agent/utils"
+	"github.com/findy-network/findy-agent/core"
 	"github.com/findy-network/findy-agent/enclave"
 	"github.com/findy-network/findy-agent/method"
 	"github.com/findy-network/findy-wrapper-go"
@@ -72,7 +73,7 @@ type Agency struct{}
 // AnchorAgent Builds new trust anchor agent and its wallet. This is quite slow process. In
 // future we could build them in advance to pool where we could allocate them
 // when needed. Needs to wallet renaming or indexing.
-func AnchorAgent(agentName, seed string) (agent *cloud.Agent, err error) {
+func AnchorAgent(agentName, seed string) (agent *cloud.Agent, caDid core.DID, err error) {
 	defer err2.Annotate("create archor", &err)
 
 	key := try.To1(enclave.NewWalletKey(agentName))
@@ -109,9 +110,10 @@ func AnchorAgent(agentName, seed string) (agent *cloud.Agent, err error) {
 	accessmgr.Send(agent.WalletH)
 
 	glog.V(2).Infof("--- Saving enclave key for %s", anchorDid.KID())
-	try.To(enclave.SetKeysDID(key, anchorDid.KID()))
+	caDid = try.To1(agent.NewDID(method.TypeSov, ""))
+	try.To(enclave.SetKeysDID(key, caDid.Did()))
 
-	return agent, nil
+	return agent, caDid, nil
 }
 
 // SetSteward sets the steward agent of this Agency.
@@ -137,13 +139,13 @@ func LoadRegistered(filename string) (err error) {
 		// still JSON file there is possibility for a human error.
 		alreadyRegistered := make(map[string]bool)
 
-		agency.Register.EnumValues(func(rootDid string, values []string) (next bool) {
+		agency.Register.EnumValues(func(caDID string, values []string) (next bool) {
 			// default is to continue even on cached errors, set this that
 			// even on panics we will continue
 			next = true
 
 			email := values[0]
-			caDID := values[1]
+			rootDid := values[1]
 			caVerKey := ""
 			if len(values) == 3 {
 				caVerKey = values[2]
@@ -160,12 +162,12 @@ func LoadRegistered(filename string) (err error) {
 				glog.V(2).Infof("Loading enclave key for root: %s, ca: %s", rootDid, caDID)
 
 				key := try.To1(enclave.WalletKeyByEmail(email))
-				keyByDid := try.To1(enclave.WalletKeyByDID(rootDid))
+				keyByDid := try.To1(enclave.WalletKeyByDID(caDID))
 
 				if key != keyByDid {
 					// key values are left out from logs in purpose
 					glog.Warningf("-------------------------------\n"+
-						"key by email (%s) don't match key by rootDid\n"+
+						"key by email (%s) don't match key by caDid\n"+
 						"using key by email", email)
 				}
 

--- a/cmds/agency/migrate.go
+++ b/cmds/agency/migrate.go
@@ -3,12 +3,8 @@ package agency
 import (
 	"io"
 	"path/filepath"
-	"strings"
 
 	ag "github.com/findy-network/findy-agent/agent/agency"
-	"github.com/findy-network/findy-agent/agent/cloud"
-	"github.com/findy-network/findy-agent/agent/comm"
-	"github.com/findy-network/findy-agent/agent/ssi"
 	"github.com/findy-network/findy-agent/agent/utils"
 	"github.com/findy-network/findy-agent/cmds"
 	"github.com/findy-network/findy-agent/enclave"
@@ -46,63 +42,65 @@ func (c MigrateCmd) Exec(w io.Writer) (r cmds.Result, err error) {
 	try.To(c.sealedBox())
 	try.To(ag.Register.Load(c.InputReg))
 
-	registeredWallets := make(map[string]seedAgent)
+	cmds.Fprintln(w, "This migrate cmd is outdated.")
 
-	cmds.Fprintln(w, "Processing starts, please wait..")
-	ag.Register.EnumValues(func(rootDid string, values []string) (next bool) {
-		// dont let crash on panics
-		defer err2.Catch(func(err error) {
-			cmds.Fprintln(w, "enum register error:", err)
-		})
-		next = true // default is to continue even on error
-		email := values[0]
-		caDid := values[1]
+	//registeredWallets := make(map[string]seedAgent)
 
-		rippedEmail := strings.Replace(email, "@", "_", -1)
-		_, walletExist := registeredWallets[rippedEmail]
-		if !walletExist {
-			key, err := enclave.WalletKeyByEmail(email)
-			keyByDid, error2 := enclave.WalletKeyByDID(rootDid)
-			if err != nil || error2 != nil {
-				cmds.Fprintln(w, "cannot get wallet key:", err, email, caDid)
-				return true
-			}
-			if key != keyByDid {
-				cmds.Fprintln(w, "keys don't match", key, keyByDid)
-			}
+	// cmds.Fprintln(w, "Processing starts, please wait..")
+	// ag.Register.EnumValues(func(rootDid string, values []string) (next bool) {
+	// 	// dont let crash on panics
+	// 	defer err2.Catch(func(err error) {
+	// 		cmds.Fprintln(w, "enum register error:", err)
+	// 	})
+	// 	next = true // default is to continue even on error
+	// 	email := values[0]
+	// 	caDid := values[1]
 
-			aw := ssi.NewRawWalletCfg(rippedEmail, key)
-			if !aw.Exists(false) {
-				cmds.Fprintf(w, "wallet '%s' not exist\n", rippedEmail)
-				return true
-			}
+	// 	rippedEmail := strings.Replace(email, "@", "_", -1)
+	// 	_, walletExist := registeredWallets[rippedEmail]
+	// 	if !walletExist {
+	// 		key, err := enclave.WalletKeyByEmail(email)
+	// 		keyByDid, error2 := enclave.WalletKeyByDID(rootDid)
+	// 		if err != nil || error2 != nil {
+	// 			cmds.Fprintln(w, "cannot get wallet key:", err, email, caDid)
+	// 			return true
+	// 		}
+	// 		if key != keyByDid {
+	// 			cmds.Fprintln(w, "keys don't match", key, keyByDid)
+	// 		}
 
-			seed := cloud.NewSeedAgent(rootDid, caDid, "", aw)
-			h := try.To1(seed.Migrate())
+	// 		aw := ssi.NewRawWalletCfg(rippedEmail, key)
+	// 		if !aw.Exists(false) {
+	// 			cmds.Fprintf(w, "wallet '%s' not exist\n", rippedEmail)
+	// 			return true
+	// 		}
 
-			a := h.(comm.Receiver)
-			vk := a.MyDID().VerKey()
+	// 		seed := cloud.NewSeedAgent(rootDid, caDid, "", aw)
+	// 		h := try.To1(seed.Migrate())
 
-			registeredWallets[rippedEmail] = seedAgent{
-				Name:     rippedEmail,
-				RootDID:  rootDid,
-				CADID:    caDid,
-				CAVerKey: vk,
-			}
+	// 		a := h.(comm.Receiver)
+	// 		vk := a.MyDID().VerKey()
 
-		} else {
-			cmds.Fprintln(w, "Duplicate registered wallet:", email)
-		}
-		return true
-	})
-	cmds.Fprintln(w, "Processing done")
+	// 		registeredWallets[rippedEmail] = seedAgent{
+	// 			Name:     rippedEmail,
+	// 			RootDID:  rootDid,
+	// 			CADID:    caDid,
+	// 			CAVerKey: vk,
+	// 		}
 
-	cmds.Fprintln(w, "Saving starts")
-	for _, sa := range registeredWallets {
-		ag.Register.Add(sa.RootDID, sa.Name, sa.CADID, sa.CAVerKey)
-	}
-	try.To(ag.Register.Save(c.OutputReg))
-	cmds.Fprintln(w, "All ready")
+	// 	} else {
+	// 		cmds.Fprintln(w, "Duplicate registered wallet:", email)
+	// 	}
+	// 	return true
+	// })
+	// cmds.Fprintln(w, "Processing done")
+
+	// cmds.Fprintln(w, "Saving starts")
+	// for _, sa := range registeredWallets {
+	// 	ag.Register.Add(sa.RootDID, sa.Name, sa.CADID, sa.CAVerKey)
+	// }
+	// try.To(ag.Register.Save(c.OutputReg))
+	// cmds.Fprintln(w, "All ready")
 
 	return nil, nil
 }

--- a/grpc/server/agency.go
+++ b/grpc/server/agency.go
@@ -14,7 +14,6 @@ import (
 	"github.com/findy-network/findy-agent/agent/psm"
 	"github.com/findy-network/findy-agent/agent/utils"
 	"github.com/findy-network/findy-agent/enclave"
-	"github.com/findy-network/findy-agent/method"
 	ops "github.com/findy-network/findy-common-go/grpc/ops/v1"
 	"github.com/findy-network/findy-common-go/jwt"
 	"github.com/golang/glog"
@@ -49,14 +48,13 @@ func (a agencyService) Onboard(
 	}
 
 	agentName := strings.Replace(onboarding.Email, "@", "_", -1)
-	ac := try.To1(handshake.AnchorAgent(agentName, onboarding.PublicDIDSeed))
+	ac, caDID := try.To2(handshake.AnchorAgent(agentName, onboarding.PublicDIDSeed))
 
-	caDID := try.To1(ac.NewDID(method.TypeSov, ""))
 	DIDStr := caDID.Did()
 	caVerKey := caDID.VerKey()
 
 	agency.AddHandler(DIDStr, ac)
-	agency.Register.Add(ac.RootDid().Did(), agentName, DIDStr, caVerKey)
+	agency.Register.Add(DIDStr, agentName, ac.RootDid().Did(), caVerKey)
 
 	ac.SetMyDID(caDID)
 

--- a/scripts/e2e/e2e-test.sh
+++ b/scripts/e2e/e2e-test.sh
@@ -311,7 +311,14 @@ onboard_no_steward() {
 
   # register two users with same seed
   findy-agent-cli authn register -u $same_seed_user
+  jwt=$(findy-agent-cli authn login -u $same_seed_user)
+  invitation=$(findy-agent-cli agent invitation --jwt="$jwt")
+  echo "First invitation: $invitation"
+
   findy-agent-cli authn register -u $user
+  jwt=$(findy-agent-cli authn login -u $user)
+  invitation=$(findy-agent-cli agent invitation --jwt="$jwt")
+  echo "Second invitation: $invitation"
 
   # restart agency
   stop_agency

--- a/scripts/e2e/e2e-test.sh
+++ b/scripts/e2e/e2e-test.sh
@@ -65,6 +65,7 @@ clean() {
   set +e
   rm findy.bolt
   set -e
+  echo "{}" > findy.json
 }
 
 stop_agency() {
@@ -288,6 +289,8 @@ onboard_no_steward() {
   export FCLI_AGENCY_HOST_PORT="8090"
   export FCLI_AGENCY_SERVER_PORT="8090"
   export FCLI_AGENCY_GRPC_CERT_PATH="./scripts/dev/docker/cert"
+  export FCLI_LOGGING="-logtostderr=true -v=7"
+
 
   # run agency
   echo -e "${BLUE}*** onboard - no steward ***${NC}"

--- a/scripts/e2e/e2e-test.sh
+++ b/scripts/e2e/e2e-test.sh
@@ -315,6 +315,7 @@ onboard_no_steward() {
   # restart agency
   stop_agency
   sleep 2
+  cat findy.json
   $CLI agency start --logging="-logtostderr=true -v=7" &
   sleep 2
   curl -f localhost:8090

--- a/scripts/e2e/e2e-test.sh
+++ b/scripts/e2e/e2e-test.sh
@@ -307,6 +307,10 @@ onboard_no_steward() {
   # onboard
   timestamp=$(date +%s)
   user="user-$timestamp"
+  same_seed_user="same-seed-user-$timestamp"
+
+  # first register user with same seed
+  findy-agent-cli authn register -u $same_seed_user
 
   findy-agent-cli authn register -u $user
   jwt=$(findy-agent-cli authn login -u $user)
@@ -320,6 +324,7 @@ onboard_no_steward() {
   sleep 2
   curl -f localhost:8090
 
+  # check that we can create invitations after users are reloaded
   jwt=$(findy-agent-cli authn login -u $user)
   invitation=$(findy-agent-cli agent invitation --jwt="$jwt")
 

--- a/scripts/e2e/e2e-test.sh
+++ b/scripts/e2e/e2e-test.sh
@@ -79,6 +79,7 @@ init_agency(){
   rm -rf ~/.indy_client/
   rm findy.bolt
   set -e
+  echo "{}" > findy.json
 }
 
 init_ledger() {
@@ -289,12 +290,11 @@ onboard_no_steward() {
   export FCLI_AGENCY_HOST_PORT="8090"
   export FCLI_AGENCY_SERVER_PORT="8090"
   export FCLI_AGENCY_GRPC_CERT_PATH="./scripts/dev/docker/cert"
-  export FCLI_LOGGING="-logtostderr=true -v=7"
 
 
   # run agency
   echo -e "${BLUE}*** onboard - no steward ***${NC}"
-  $CLI agency start &
+  $CLI agency start --logging="-logtostderr=true -v=7" &
   sleep 2
   curl -f localhost:8090
 
@@ -315,7 +315,7 @@ onboard_no_steward() {
   # restart agency
   stop_agency
   sleep 2
-  $CLI agency start &
+  $CLI agency start --logging="-logtostderr=true -v=7" &
   sleep 2
   curl -f localhost:8090
 

--- a/scripts/e2e/e2e-test.sh
+++ b/scripts/e2e/e2e-test.sh
@@ -309,26 +309,26 @@ onboard_no_steward() {
   user="user-$timestamp"
   same_seed_user="same-seed-user-$timestamp"
 
-  # first register user with same seed
+  # register two users with same seed
   findy-agent-cli authn register -u $same_seed_user
-
   findy-agent-cli authn register -u $user
-  jwt=$(findy-agent-cli authn login -u $user)
-  invitation=$(findy-agent-cli agent invitation --jwt="$jwt")
 
   # restart agency
   stop_agency
   sleep 2
-  cat findy.json
+
   $CLI agency start --logging="-logtostderr=true -v=7" &
   sleep 2
   curl -f localhost:8090
 
   # check that we can create invitations after users are reloaded
+  jwt=$(findy-agent-cli authn login -u $same_seed_user)
+  invitation=$(findy-agent-cli agent invitation --jwt="$jwt")
+  echo "First invitation: $invitation"
+
   jwt=$(findy-agent-cli authn login -u $user)
   invitation=$(findy-agent-cli agent invitation --jwt="$jwt")
-
-  echo "Invitation: $invitation"
+  echo "Second invitation: $invitation"
 
   stop_agency
 }


### PR DESCRIPTION
* Add e2e test for stewardless agency restart onboarding two users with similar public DID seed
* Change register/enclave loading so that caDID is used as the key: previous logic overrides new onboards with same public DID
* Comment out migrate cmd, as it no longer works. Thinking about leaving it as a placeholder still, if similar cmd is needed in the future.
* This change is breaking the agency logic so that existing onboards will no longer work. I think that is acceptable in this phase.