### PR TITLE
Use common actions for full e2e test, linting and scanning

### DIFF
--- a/.github/workflows/iop.yml
+++ b/.github/workflows/iop.yml
@@ -36,7 +36,7 @@ jobs:
           docker logs docker_core_1 > scripts/aath/.logs/docker_core_1-$(date +%s).log 2>&1 &
       - name: archive logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: iop-logs
           path: scripts/aath/.logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,17 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
-    container: ghcr.io/findy-network/findy-base:indy-1.16.ubuntu-18.04
     env:
       TEST_WORKDIR: /github/home/.test/
       CI: true
     steps:
+      # install indy
+      - uses: actions/checkout@v3
+        with:
+          repository: "findy-network/findy-wrapper-go"
+      - name: install indy
+        run: make indy_to_debian
+
       - name: setup go, lint and scan
         uses: findy-network/setup-go-action@master
         with:
@@ -122,6 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check]
     steps:
+      # TODO: implement graceful shutdown to collect coverage data
       - name: test e2e flow
         uses: findy-network/e2e-test-action@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
           FCLI_AGENCY_POOL_NAME: "FINDY_LEDGER,von"
 
       - name: store coverage file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}-coverage1.txt
           path: ./coverage1.txt
@@ -100,7 +100,7 @@ jobs:
           FCLI_AGENCY_DID_METHOD: "2"
 
       - name: store coverage file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}-coverage2.txt
           path: ./coverage2.txt
@@ -133,26 +133,6 @@ jobs:
       - name: docker image
         run: make image
 
-  upload-coverage:
-    runs-on: ubuntu-latest
-    needs: [test-default, test-peer]
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: download coverage file
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ github.sha }}-coverage1.txt
-      - name: download coverage file
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ github.sha }}-coverage2.txt
-      - name: upload coverage
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./coverage1.txt,./coverage2.txt
-          fail_ci_if_error: true
-
   e2e:
     runs-on: ubuntu-latest
     needs: [lint]
@@ -178,12 +158,58 @@ jobs:
         run: make e2e_ci
       - name: Collect docker logs
         if: ${{ failure() }}
-        uses: jwalton/gh-docker-logs@v2.0.2
+        uses: jwalton/gh-docker-logs@v2
         with:
           dest: "./tests_output/docker-logs"
       - name: archive logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: e2e-logs
           path: tests_output
+
+  e2e-full:
+    runs-on: ubuntu-latest
+    steps:
+      - name: test e2e flow
+        uses: findy-network/e2e-test-action@master
+        with:
+          service: "core"
+          service-context: ./
+          service-dockerfile: ./scripts/deploy/Dockerfile
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: './go.mod'
+      - name: convert coverage to txt
+        run: go tool covdata textfmt -i=coverage -o coverage-e2e.txt
+      - name: store coverage file
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.sha }}-coverage-e2e.txt
+          path: ./coverage-e2e.txt
+          retention-days: 1
+
+  upload-coverage:
+    runs-on: ubuntu-latest
+    needs: [test-default, test-peer, e2e-full]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: download coverage file
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ github.sha }}-coverage1.txt
+      - name: download coverage file
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ github.sha }}-coverage2.txt
+      - name: download coverage file
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ github.sha }}-coverage-e2e.txt
+      - name: upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage1.txt,./coverage2.txt,./coverage-e2e.txt
+          fail_ci_if_error: true
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,27 +3,34 @@ on:
   push:
 jobs:
 
-  lint:
+  check:
     runs-on: ubuntu-latest
+    container: ghcr.io/findy-network/findy-base:indy-1.16.ubuntu-18.04
+    env:
+      TEST_WORKDIR: /github/home/.test/
+      CI: true
     steps:
-      - uses: actions/setup-go@v3
+      - name: setup go, lint and scan
+        uses: findy-network/setup-go-action@master
         with:
-          go-version: 1.20.x
-      - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+          linter-config-path: .golangci.yml
+
+      - name: test and measure coverage (peer did)
+        run: make test_cov_out COV_FILE=coverage-peer.txt
+        env:
+          FCLI_AGENCY_DID_METHOD: "2"
+
+      - name: store coverage file
+        uses: actions/upload-artifact@v3
         with:
-          args: "--out-${NO_FUTURE}format colored-line-number --timeout=15m"
-          version: v1.51.1
-          skip-cache: true
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          skip-pkg-cache: true
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          skip-build-cache: true
+          name: ${{ github.sha }}-coverage-peer.txt
+          path: ./coverage-peer.txt
+          retention-days: 1
+
 
   test-default:
     runs-on: ubuntu-latest
-    needs: [lint]
+    needs: [check]
     env:
       TEST_WORKDIR: /github/home/.test/
       CI: true
@@ -54,7 +61,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.x
+          go-version-file: './go.mod'
       - name: checkout
         uses: actions/checkout@v3
 
@@ -62,7 +69,7 @@ jobs:
       - name: test and measure coverage
         run: |
           curl http://localhost:9000/genesis > gen_txn_file
-          make test_grpcv_cov_out COV_FILE=coverage1.txt
+          make test_grpcv_cov_out COV_FILE=coverage-default.txt
         env:
           TEST_TIMEOUT: 6000s
           TEST_ARGS: "-vmodule=grpc_test*=5 -v=0 -logtostderr"
@@ -72,70 +79,13 @@ jobs:
       - name: store coverage file
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.sha }}-coverage1.txt
-          path: ./coverage1.txt
+          name: ${{ github.sha }}-coverage-default.txt
+          path: ./coverage-default.txt
           retention-days: 1
-
-  test-peer:
-    runs-on: ubuntu-latest
-    needs: [lint]
-    container: ghcr.io/findy-network/findy-base:indy-1.16.ubuntu-18.04
-    env:
-      TEST_WORKDIR: /github/home/.test/
-      CI: true
-    steps:
-      - name: Install make & certs
-        run: apt-get update && apt-get install -y build-essential ca-certificates
-      - name: setup
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-      - name: checkout
-        uses: actions/checkout@v3
-
-      # test round for peer-did and mem-ledger
-      - name: test and measure coverage (peer did)
-        run: make test_cov_out COV_FILE=coverage2.txt
-        env:
-          FCLI_AGENCY_DID_METHOD: "2"
-
-      - name: store coverage file
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ github.sha }}-coverage2.txt
-          path: ./coverage2.txt
-          retention-days: 1
-
-  license-scan:
-    runs-on: ubuntu-latest
-    needs: [lint]
-    container: ghcr.io/findy-network/findy-base:indy-1.16.ubuntu-18.04
-    steps:
-      - name: Install make & certs
-        run: apt-get update && apt-get install -y build-essential ca-certificates curl
-      - name: setup
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-      - name: checkout
-        uses: actions/checkout@v3
-
-      # licence scan
-      - name: scan
-        run: make scan | grep "Licensing OK"
-
-  test-docker-image:
-    runs-on: ubuntu-latest
-    needs: [lint]
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: docker image
-        run: make image
 
   e2e:
     runs-on: ubuntu-latest
-    needs: [lint]
+    needs: [check]
     steps:
       # install indy
       - uses: actions/checkout@v3
@@ -146,7 +96,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.x
+          go-version-file: './go.mod'
       - name: checkout
         uses: actions/checkout@v3
       - name: install cli
@@ -170,6 +120,7 @@ jobs:
 
   e2e-full:
     runs-on: ubuntu-latest
+    needs: [check]
     steps:
       - name: test e2e flow
         uses: findy-network/e2e-test-action@master
@@ -191,25 +142,25 @@ jobs:
 
   upload-coverage:
     runs-on: ubuntu-latest
-    needs: [test-default, test-peer, e2e-full]
+    needs: [check, test-default, e2e-full]
     steps:
       - name: checkout
         uses: actions/checkout@v3
       - name: download coverage file
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
-          name: ${{ github.sha }}-coverage1.txt
+          name: ${{ github.sha }}-coverage-default.txt
       - name: download coverage file
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
-          name: ${{ github.sha }}-coverage2.txt
+          name: ${{ github.sha }}-coverage-peer.txt
       - name: download coverage file
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ github.sha }}-coverage-e2e.txt
       - name: upload coverage
         uses: codecov/codecov-action@v3
         with:
-          files: ./coverage1.txt,./coverage2.txt,./coverage-e2e.txt
+          files: ./coverage-default.txt,./coverage-peer.txt,./coverage-e2e.txt
           fail_ci_if_error: true
 

--- a/scripts/aath/Makefile
+++ b/scripts/aath/Makefile
@@ -22,7 +22,7 @@ prep: record-logs
 # by default tags are defined in findy-agent-backchannel
 test: prep
 	cd .docker/findy-agent-backchannel/env && \
-		make aath-test \
+		make aath \
 			AGENT_DEFAULT=$(AGENT_DEFAULT) \
 			AGENT_BOB=$(AGENT_BOB) \
 			INCLUDE_TAGS=$(INCLUDE_TAGS)
@@ -30,7 +30,7 @@ test: prep
 # check returns failure exit code, suitable for CI
 test-check: prep
 	cd .docker/findy-agent-backchannel/env && \
-		make aath-test-check \
+		make aath-check \
 			AGENT_DEFAULT=$(AGENT_DEFAULT) \
 			AGENT_BOB=$(AGENT_BOB)
 


### PR DESCRIPTION
Use common action for
* linting
* license scanning
* full agency e2e test

Remove separate jobs for linting, license scanning and docker image building as they are included in other jobs.

Note: coverage measurements for full agency e2e test is not implemented yet as it needs the server to gracefully shutdown.